### PR TITLE
Added ROS-on-EV3 to post for Project Gallery

### DIFF
--- a/_posts/2014-11-17-ROS-on-EV3.md
+++ b/_posts/2014-11-17-ROS-on-EV3.md
@@ -1,0 +1,56 @@
+---
+author: [ "@moriarty"] 
+programming_language: "python, c++, bash" 
+youtube_video_id: ZgA7DgbuVEs
+
+project_homepage_url: "http://wiki.ros.org/Robots/EV3" # Homepage for this project
+source_code_url: "https://github.com/moriarty/ros-ev3" # Provide a link to your code
+building_instructions_url: "https://github.com/moriarty/ros-ev3/blob/master/brickstrap-build-status.md"
+---
+
+
+- **Name:** Alexander Moriarty
+- **Location:** Cologne, Germany 
+- **Feedback:** [gh.com/moriarty/ros-ev3/issues](https://github.com/moriarty/ros-ev3/issues)
+- **Project Status::** work in progress (on pause)
+
+
+There isn't much programming involved yet, just a how to get ROS onto an EV3. This project [Source Code](https://github.com/moriarty/ros-ev3) is home to 
+the latest HowTo.
+
+
+I'm interested in running/using [ROS](http://www.ros.org/) with EV3s. There was is a 
+[project](http://wiki.ros.org/Robots/NXT) which interfaced the NXT with ROS, but it doesn't seem to be maintained. 
+version of ROS which the NXT stack is recommended is DiamondBack, which was supported up to Ubuntu 11.04. 
+
+
+The EV3 is much more capable that the NXT, so I was surprised I only found people asking on forums if 
+ROS ran on the EV3 and didn't find anyone actually try it out. I've created a [wiki entry for the EV3](http://wiki.ros.org/Robots/EV3) on ROS.org. 
+
+
+So far I have only had the time to prove it is possible to install the 
+[ros communication stack](http://wiki.ros.org/ros_comm) onto an EV3 running ev3dev. 
+
+
+I was unable to run [roscore](http://wiki.ros.org/roscore) in ev3dev on the EV3.  However, after connecting the EV3 to 
+a network (via USB adapter) and with a ```roscore``` running on a laptop, I was able to run the talker and listener nodes
+from the [ROS python tutorials](http://wiki.ros.org/ROS/Tutorials/WritingPublisherSubscriber(python)) on the EV3. 
+
+
+This very basic example is shown in the above YouTube video. It is NOT an interesting video, it has no sound, and it's basically just some 
+terminal windows. I've connected to both the laptop running ```roscore``` and the EV3 via ```ssh``` from a virtual machine. It should be noded that 
+starting the python ros nodes is not quick, but once started they appear to run fine. At 2:37 I start run ```listener.py```
+and according to the video it takes about 15 seconds for the listener to start printing the recieved messages. I also forget to 
+source the ROS ```setup.bash``` and set the ```ROS_MASTER_URI``` environment variable, I didn't edit the video, hopefully this reminds others
+not to make the same mistake. I'll try to replace the video with something cooler soon.
+
+
+I think the next step is to write either one rosnode for each type of sensors, publishing the data to rostopics, 
+and one rosnode which provides an interface to the motors via publishing to rostopics. Or possibly one highly 
+configurable rosnode which provides all the interfaces for sensors and motors. It needs to be tested which approach 
+is more system heavy. 
+
+
+I unfortunately don't have much time to play with this project again until the new year. 
+But I am sharing now for those who are interested. 
+


### PR DESCRIPTION
Sharing my project with a HowTo get [ros/ros_comm](https://github.com/ros/ros_comm) on to an EV3 with ev3dev.

It's a work in progress but I cleaned up the HowTo last week to share it now as I know I won't have time to work on it again over the next several weeks. 
