### PR TITLE
Link to nxt-analog-host no longer exists

### DIFF
--- a/docs/sensors/index.md
+++ b/docs/sensors/index.md
@@ -152,7 +152,7 @@ kernel.
 [^nxt-analog]: The auto-detection algorithm detects this sensor as an Analog/NXT
     type sensor but it cannot determine the exact sensor type. The generic
     analog driver (nxt-analog) will be loaded by default for this sensor. See the
-    [NXT Analog Host Driver] for information on how to manually load the
+    [NXT Analog Sensor Driver] for information on how to manually load the
     correct driver.
 
 [^standard-i2c]: The auto-detection algorithm detects this sensor as an I2C
@@ -179,7 +179,7 @@ kernel.
 [LEGO 8528]: http://www.bricklink.com/catalogItem.asp?S=8528-1
 [I2C protocol]: https://en.wikipedia.org/wiki/I2c
 [I2C Sensor Addressing]: i2c-sensor-addressing
-[NXT Analog Host Driver]: http://www.ev3dev.org/docs/drivers/nxt-analog-host/
+[NXT Analog Sensor Driver]: http://www.ev3dev.org/docs/drivers/nxt-analog-sensor/
 [Using I2C Sensors]: using-i2c-sensors
 [UART]: https://en.wikipedia.org/wiki/Uart
 [using-uart-sensors-on-any-linux]: http://lechnology.com/2014/09/using-uart-sensors-on-any-linux/


### PR DESCRIPTION
Per update at 3.16.1-8-ev3dev  "*host" drivers for input ports removed and merged functionality into the
"lego-port" class. Link to http://www.ev3dev.org/docs/drivers/nxt-analog-host/ is no longer valid.

Please verify that the updated link indeed is the correct one.
