### PR TITLE
Users should be in input group

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -148,7 +148,7 @@ command to assign groups hiding at the end.
     	Home Phone []: 
     	Other []: 
     Is the information correct? [Y/n] y
-    root@ev3dev:~# usermod -a -G sudo,ev3dev,plugdev,audio,video user
+    root@ev3dev:~# usermod -a -G sudo,ev3dev,plugdev,audio,video,input user
 
 ### Set the time zone
 


### PR DESCRIPTION
In order to have access to brick buttons, users should be in `input` group.