### PR TITLE
Add Clojure to the list of extra languages.

### DIFF
--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -33,3 +33,4 @@ We also have many great contrubutors that are maintaining extra libraries for la
     * [Google Go](https://github.com/ldmberman/GoEV3) updated for ev3dev-jessie by @ldmberman, [original](https://github.com/mattrajca/GoEV3) by @mattrajca
     * [Python](https://github.com/topikachu/python-ev3) by @topikachu
     * [C (with optional Perl, Python and Ruby bindings)](https://github.com/in4lio/ev3dev-c) by @in4lio
+    * [Clojure](https://github.com/annapawlicka/clj-ev3dev) by @annapawlicka

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -33,4 +33,4 @@ We also have many great contrubutors that are maintaining extra libraries for la
     * [Google Go](https://github.com/ldmberman/GoEV3) updated for ev3dev-jessie by @ldmberman, [original](https://github.com/mattrajca/GoEV3) by @mattrajca
     * [Python](https://github.com/topikachu/python-ev3) by @topikachu
     * [C (with optional Perl, Python and Ruby bindings)](https://github.com/in4lio/ev3dev-c) by @in4lio
-    * [Clojure](https://github.com/annapawlicka/clj-ev3dev) by @annapawlicka
+    * [Clojure (remote control only)](https://github.com/annapawlicka/clj-ev3dev) by @annapawlicka


### PR DESCRIPTION
I've created a Clojure wrapper around ev3dev API. It uses ssh to send commands (as starting Clojure REPL on ev3 is not possible due to its heavy system requirements). It's still WIP but it's got most of the functionality covered.