### PR TITLE
Drop 'remote only' flag

### DIFF
--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -33,4 +33,4 @@ We also have many great contrubutors that are maintaining extra libraries for la
     * [Google Go](https://github.com/ldmberman/GoEV3) updated for ev3dev-jessie by @ldmberman, [original](https://github.com/mattrajca/GoEV3) by @mattrajca
     * [Python](https://github.com/topikachu/python-ev3) by @topikachu
     * [C (with optional Perl, Python and Ruby bindings)](https://github.com/in4lio/ev3dev-c) by @in4lio
-    * [Clojure (remote control only)](https://github.com/annapawlicka/clj-ev3dev) by @annapawlicka
+    * [Clojure](https://github.com/annapawlicka/clj-ev3dev) by @annapawlicka


### PR DESCRIPTION
I've modified the library to run on ev3. 

I've renamed the ssh version to [clj-ev3dev-remote](https://github.com/annapawlicka/clj-ev3dev-remote). I prefer it for development as it's more performant.