### PR TITLE
Added informations about the magic number in the battery icon

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,6 +89,8 @@ like this on the screen:
 
 {% include screenshot.html source="/images/brickman/main-menu.png" %}
 
+You will notice the number in the battery in the upper right corner. This displays the remaining voltage of the power supply. It is not possible to calculate an accurate percent value of the remaining energy, so this value is choosen. If the voltage drops below 5V the brick will turn off. All not saved data may be lost. Keep in mind, that is may take a much longer time from 8V to 6.5V than from 6.5V down to 5V!
+
 **Troubleshooting tips if your EV3 won't boot:**
 
 * Make sure nothing is plugged into the EV3 (USB/sensors/motors/etc.)


### PR DESCRIPTION
I thought somewhere in the wiki should be explained, what the "8.0" in the picture means. I first thought this is some kind of version and my fresh installed Debian is already oudated (becase I had only "Version" 7.39). Even if you know, that this is the remaining energy, it isn't obvious, that the brick will die at ~5V.