### PR TITLE
Constrain logo

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -1122,7 +1122,7 @@ section #title p {
 
 #logo {
     float:left;
-    max-height:140%;
+    max-height:120%;
     width:auto;
     max-width:15%;
     position: absolute;


### PR DESCRIPTION
The new org logo is bigger than the old one, so it overlapped the rest of the header.