### PR TITLE
Update python-ev3dev installation instructions

### DIFF
--- a/projects/_posts/2015-05-06-EV3-Print3rbot.md
+++ b/projects/_posts/2015-05-06-EV3-Print3rbot.md
@@ -19,7 +19,7 @@ The python code is using the [Python API](https://github.com/ddemidov/ev3dev-lan
 
 *   Now, the actual module installation:
 
-        easy_install http://ddemidov.github.io/ev3dev-lang-python/python_ev3dev-latest.egg
+        easy_install -U python-ev3dev
 
 The ev3dev version must be at least [ev3dev-jessie-2015-05-01](https://github.com/ev3dev/ev3dev/releases/tag/ev3dev-jessie-2015-05-01).
 


### PR DESCRIPTION
It was mentioned on irc channel that the instructions are outdated.