### PR TITLE
Do not include example project into projects page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,10 @@
             </a>
             <ul class="button-dropdown">
                 <li>
-                    <a href="{{ site.github.url }}/share" title="Discover and share projects that use ev3dev">Share</a>
+                    <a href="{{ site.github.url }}/projects" title="Discover projects that use ev3dev">Projects</a>
+                </li>
+                <li>
+                    <a href="{{ site.github.url }}/share" title="Share projects that use ev3dev">Share</a>
                 </li>
                 <li>
                     <a href="{{ site.github.url }}/contribute" title="How to contribute to ev3dev">Contribute</a>

--- a/projects/index.md
+++ b/projects/index.md
@@ -12,23 +12,25 @@ Would you like your project added to the list? We would!
 <ul id="projects-list">
     {% for post in site.posts %}
         {% if post.categories contains "projects" %}
-            <li>
-                <div class="project-tile-title">
-                    <h4>
-                        <a href="{{ site.github.url }}{{ post.url }}">{{ post.title }}</a>
-                    </h4>
-                </div>
-                {% assign num_words = 40 %}
-                {% if post.youtube_video_id %}
-                    {% assign num_words = 20 %}
-                    <a href="{{ site.github.url }}{{ post.url }}">
-                        <img class="project-tile-img" src="http://img.youtube.com/vi/{{post.youtube_video_id}}/mqdefault.jpg" />
-                    </a>
-                {% endif %}
-                <span class="project-tile-excerpt">
-                    {{ post.excerpt | truncatewords: num_words }}
-                </span>
-            </li>
+            {% unless post.id == '/projects/2014/03/21/Example-Project' %}
+                <li>
+                    <div class="project-tile-title">
+                        <h4>
+                            <a href="{{ site.github.url }}{{ post.url }}">{{ post.title }}</a>
+                        </h4>
+                    </div>
+                    {% assign num_words = 40 %}
+                    {% if post.youtube_video_id %}
+                        {% assign num_words = 20 %}
+                        <a href="{{ site.github.url }}{{ post.url }}">
+                            <img class="project-tile-img" src="http://img.youtube.com/vi/{{post.youtube_video_id}}/mqdefault.jpg" />
+                        </a>
+                    {% endif %}
+                    <span class="project-tile-excerpt">
+                        {{ post.excerpt | truncatewords: num_words }}
+                    </span>
+                </li>
+            {% endunless %}
         {% endif %}
     {% endfor %}
 </ul>

--- a/share.md
+++ b/share.md
@@ -13,8 +13,8 @@ ev3dev.org Projects Page
 We currently have a [projects page] where you can browse projects that have been
 built using ev3dev. You can add your own too!
 
-{% assign project = site.categories.projects | first %}
-Here is the most recent project ([more about this project...]({{ site.github.url }}{{ project.url}})).
+{% assign project = site.categories.projects | last %}
+Here is the sample project ([more about this project...]({{ site.github.url }}{{ project.url}})).
 
 ###{{ project.title }}
 


### PR DESCRIPTION
The link to the project is still present on the Share page.

This is a result of irc discussion with @cavenel.