### PR TITLE
Add favicon (for realz this time)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,6 +5,7 @@
 
     <title>{{ page.title }}</title>
     <link rel="alternate" type="application/atom+xml" href="{{ site.github.url }}/news/atom.xml" title="Atom feed">
+    <link rel="icon" href="favicon.ico" />
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="{{ site.github.url }}/stylesheets/bootstrap.css">


### PR DESCRIPTION
Couldn't figure out why the favicon wasn't appearing on `www.ev3dev.org`...