### PR TITLE
Normalize and update table styles

### DIFF
--- a/_includes/motor.md
+++ b/_includes/motor.md
@@ -9,23 +9,23 @@
 
 ### General Info
 
-<table id="sensor-info">
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+<table class="table table-striped table-bordered">
+    <tr>
         <th><code>device_name</code></th>
         <td><code>{{ motor.name }}</code></td>
     </tr>
     {%if motor.vendor_website %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th>Website</th>
         {% assign split_website=motor.vendor_website | split: '/' %}
         <td><span markdown="1">[{{ split_website[2] }}]({{ motor.vendor_website }})</span></td>
     </tr>
     {% endif %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th>Connection</th>
         <td>{{ connection }}</td>
     </tr>
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th>sysfs class</th>
         <td>
             {%if motor.device_class %}
@@ -40,7 +40,7 @@
         </td>
     </tr>
     {% if motor.vendor_id %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th><code>vendor_id</code></th>
         <td>
             {{ motor.vendor_id }}<!--
@@ -52,7 +52,7 @@
     </tr>
     {% endif %}
     {% if motor.product_id %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th><code>product_id</code></th>
         <td>
             {{ motor.product_id }}<!--

--- a/_includes/port.md
+++ b/_includes/port.md
@@ -9,8 +9,8 @@
 
 ### General Info
 
-<table id="sensor-info" class="table table-striped table-bordered">
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+<table class="table table-striped table-bordered">
+    <tr>
         <th><code>device_name</code></th>
         <td><code>{{ port.name }}</code></td>
     </tr>
@@ -27,14 +27,14 @@
         <td><code>{{ port.prefix }}</code></td>
     </tr>
     {%if port.vendor_website %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th>Website</th>
         {% assign split_website=port.vendor_website | split: '/' %}
         <td><span markdown="1">[{{ split_website[2] }}]({{ port.vendor_website }})</span></td>
     </tr>
     {% endif %}
     {% if port.default_address %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th>Address</th>
         <td>
             {{ port.default_address }}<!--
@@ -45,7 +45,7 @@
         </td>
     </tr>
     {% endif %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th>sysfs class</th>
         <td>
             {%if port.device_class %}
@@ -60,7 +60,7 @@
         </td>
     </tr>
     {% if port.vendor_id %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th><code>vendor_id</code></th>
         <td>
             {{ port.vendor_id }}<!--
@@ -72,7 +72,7 @@
     </tr>
     {% endif %}
     {% if port.product_id %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th><code>product_id</code></th>
         <td>
             {{ port.product_id }}<!--
@@ -84,7 +84,7 @@
     </tr>
     {% endif %}
     {%if port.device_class == null %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th># Modes</th>
         <td>{{ port.num_modes }}</td>
     </tr>
@@ -95,7 +95,7 @@
 ### Modes
 
 <table id="sensor-modes" class="table table-striped table-bordered">
-    <tr class="{% cycle 'modes': 'd0', 'd1' %}">
+    <tr>
         <th><code>mode</code></th>
         <th>Description</th>
     </tr>
@@ -103,7 +103,7 @@
     {% if mode.notes %}
         {% assign footnotes=footnotes | append: mode.notes %}
     {% endif %}
-    <tr class="{% cycle 'modes': 'd0', 'd1' %}">
+    <tr>
         <td style="white-space:nowrap;">
             <code>{{ mode.name }}</code><!--
             {% if mode.name_footnote %}

--- a/_includes/sensor.md
+++ b/_includes/sensor.md
@@ -183,7 +183,7 @@
 {% assign num_commands = sensor.num_commands | plus: 0 %}
 {% if num_commands > 0 %}
 <table class="table table-striped table-bordered">
-    <tr">
+    <tr>
         <th><code>command</code></th>
         <th>Description</th>
     </tr>

--- a/_includes/sensor.md
+++ b/_includes/sensor.md
@@ -10,24 +10,24 @@
 
 ### General Info
 
-<table id="sensor-info" class="table table-striped table-bordered">
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+<table class="table table-striped table-bordered">
+    <tr>
         <th><code>device_name</code></th>
         <td><code>{{ sensor.name }}</code></td>
     </tr>
     {%if sensor.vendor_website %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th>Website</th>
         {% assign split_website=sensor.vendor_website | split: '/' %}
         <td><span markdown="1">[{{ split_website[2] }}]({{ sensor.vendor_website }})</span></td>
     </tr>
     {% endif %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th>Connection</th>
         <td>{{ connection }}</td>
     </tr>
     {% if sensor.default_address %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th>Address</th>
         <td>
             {{ sensor.default_address }}<!--
@@ -38,7 +38,7 @@
         </td>
     </tr>
     {% endif %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th>sysfs class</th>
         <td>
             {%if sensor.device_class %}
@@ -53,7 +53,7 @@
         </td>
     </tr>
     {% if sensor.vendor_id %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th><code>vendor_id</code></th>
         <td>
             {{ sensor.vendor_id }}<!--
@@ -65,7 +65,7 @@
     </tr>
     {% endif %}
     {% if sensor.product_id %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th><code>product_id</code></th>
         <td>
             {{ sensor.product_id }}<!--
@@ -77,7 +77,7 @@
     </tr>
     {% endif %}
     {%if sensor.device_class == null %}
-    <tr class="{% cycle 'info': 'd0', 'd1' %}">
+    <tr>
         <th># Modes</th>
         <td>{{ sensor.num_modes }}</td>
     </tr>
@@ -88,7 +88,7 @@
 ### Modes
 
 <table id="sensor-modes" class="table table-striped table-bordered">
-    <tr class="{% cycle 'modes': 'd0', 'd1' %}">
+    <tr>
         <th><code>mode</code></th>
         <th>Description</th>
         <th><code>units</code></th>
@@ -100,7 +100,7 @@
     {% if mode.notes %}
         {% assign footnotes=footnotes | append: mode.notes %}
     {% endif %}
-    <tr class="{% cycle 'modes': 'd0', 'd1' %}">
+    <tr>
         <td style="white-space:nowrap;">
             <code>{{ mode.name }}</code><!--
             {% if mode.name_footnote %}
@@ -182,8 +182,8 @@
 ### Commands
 {% assign num_commands = sensor.num_commands | plus: 0 %}
 {% if num_commands > 0 %}
-<table id="sensor-info" class="table table-striped table-bordered">
-    <tr class="{% cycle 'commands': 'd0', 'd1' %}">
+<table class="table table-striped table-bordered">
+    <tr">
         <th><code>command</code></th>
         <th>Description</th>
     </tr>
@@ -191,7 +191,7 @@
     {% if command.notes %}
         {% assign footnotes=footnotes | append: command.notes %}
     {% endif %}
-    <tr class="{% cycle 'commands': 'd0', 'd1' %}">
+    <tr>
         <td>
             <code>{{ command.name }}</code><!--
             {% if command.name_footnote %}

--- a/docs/motors/index.md
+++ b/docs/motors/index.md
@@ -58,7 +58,8 @@ kernel.
 
 ### Motors
 
-<table class="table table-striped table-bordered">
+<table class="table table-striped table-bordered table-indexed">
+    <thead>
     <tr>
     <th>Manufacturer</th>
     <th>P/N</th>
@@ -66,6 +67,8 @@ kernel.
     <th>Auto-<br />detected</th>
     <th>Driver (Module)</th>
     </tr>
+    </thead>
+    <tbody>
 {% assign prev_vendor_name = 'dummy' %}
 {% for motor_data in site.data.motors %}
     {% assign device = motor_data %}
@@ -96,6 +99,7 @@ kernel.
     </tr>
     {% assign prev_vendor_name = device.vendor_name %}
 {% endfor %}
+    </tbody>
 </table>
 
 ### LEDs

--- a/docs/motors/index.md
+++ b/docs/motors/index.md
@@ -78,7 +78,7 @@ kernel.
                 {% assign vendor_name_rowspan = vendor_name_rowspan | plus: 1 %}
             {% endif %}
         {% endfor %}
-        <td rowspan="{{ vendor_name_rowspan }}">{{ device.vendor_name }}</td>
+        <th rowspan="{{ vendor_name_rowspan }}">{{ device.vendor_name }}</th>
     {% endif %}
         <td>{{ device.vendor_part_number }}</td>
         <td><a href="{{ device.url_name }}">{{ device.vendor_part_name }}</a></td>

--- a/docs/sensors/i2c-sensor-addressing.md
+++ b/docs/sensors/i2c-sensor-addressing.md
@@ -2,12 +2,6 @@
 title: I2C Sensor Addressing
 ---
 
-<div class="alert alert-warning">
-    <span class="glyphicon glyphicon-alert"></span>
-    Due to design choices that are built in to the foundation of the LEGO ecosystem,
-    there are some nonstandard addressing schemes that you should be aware of.
-</div>
-
 I2C uses a 7-bit addressing scheme (there is also 10-bit addressing but it is
 not implemented in the ev3dev I2C driver). When sending an address over the bus,
 the address is shifted to the left 1 bit and the least significant bit is used
@@ -30,7 +24,7 @@ for special use by the I2C specifications. However, these addresses are used by
 some sensors anyway (most notably the NXT Ultrasonic sensor). The ev3dev kernel
 has been patched to allow these to work, but some userspace tools will not work
 with devices at these addresses. For example, we distribute a patched version
-of the `i2c-tools` package to workaround this.
+of the `i2c-tools` package to work around this.
 
 | Shifted Address<br />(write/read) | Unshifted Address<br />(hex (dec)) | Notes |
 |:-:|:-:|:-:|

--- a/docs/sensors/i2c-sensor-addressing.md
+++ b/docs/sensors/i2c-sensor-addressing.md
@@ -162,4 +162,4 @@ of the `i2c-tools` package to workaround this.
 | 0xFA/0xFB | __0x7D__ (125) | *I2C spec: Reserved for future purposes* |
 | 0xFC/0xFD | __0x7E__ (126) | *I2C spec: Reserved for future purposes* |
 | 0xFE/0xFF | __0x7F__ (127) | *I2C spec: Reserved for future purposes* |
-{: .table .table-striped .table-bordered }
+{: .table .table-striped .table-bordered .table-condensed }

--- a/docs/sensors/i2c-sensor-addressing.md
+++ b/docs/sensors/i2c-sensor-addressing.md
@@ -2,6 +2,12 @@
 title: I2C Sensor Addressing
 ---
 
+<div class="alert alert-warning">
+    <span class="glyphicon glyphicon-alert"></span>
+    Due to design choices that are built in to the foundation of the LEGO ecosystem,
+    there are some nonstandard addressing schemes that you should be aware of.
+</div>
+
 I2C uses a 7-bit addressing scheme (there is also 10-bit addressing but it is
 not implemented in the ev3dev I2C driver). When sending an address over the bus,
 the address is shifted to the left 1 bit and the least significant bit is used
@@ -11,14 +17,15 @@ documentation. This shifted value is also used in most other NXT/EV3
 programming languages/environments.
 
 ev3dev uses the standard Linux kernel convention, which is to use the unshifted
-value as the I2C address. **This means the address in your sensors documentation
+value as the I2C address. **This means the address in your sensors' documentation
 is probably not the address that you need for ev3dev!** Also, depending on the
 tool, the address may need to be decimal instead of hexidecimal. This means you
 will have to convert the value to get the correct address. Shift to the right
 is the same as divide by 2, so get out your calculator and do some conversions!
 Or for the engineer type folks that prefer tables... see below.
 
-**IMPORTANT NOTE**: I2C addresses 0x01 through 0x07 (unshifted) are reserved
+
+I2C addresses 0x01 through 0x07 (unshifted) are reserved
 for special use by the I2C specifications. However, these addresses are used by
 some sensors anyway (most notably the NXT Ultrasonic sensor). The ev3dev kernel
 has been patched to allow these to work, but some userspace tools will not work
@@ -155,3 +162,4 @@ of the `i2c-tools` package to workaround this.
 | 0xFA/0xFB | __0x7D__ (125) | *I2C spec: Reserved for future purposes* |
 | 0xFC/0xFD | __0x7E__ (126) | *I2C spec: Reserved for future purposes* |
 | 0xFE/0xFF | __0x7F__ (127) | *I2C spec: Reserved for future purposes* |
+{: .table .table-striped .table-bordered }

--- a/docs/sensors/index.md
+++ b/docs/sensors/index.md
@@ -104,7 +104,8 @@ or how to donate hardware to someone who will.
 This is a list of sensors that currently have drivers available in the ev3dev
 kernel.
 
-<table class="table table-striped table-bordered">
+<table class="table table-striped table-bordered table-indexed">
+    <thead>
     <tr>
     <th>Manufacturer</th>
     <th>P/N</th>
@@ -113,6 +114,8 @@ kernel.
     <th>Auto-<br />detected</th>
     <th>Driver (Module)</th>
     </tr>
+    </thead>
+    <tbody>
 {% assign prev_vendor_name = 'dummy' %}
 {% for sensor_data in site.data.sensors %}
     {% assign sensor = sensor_data %}
@@ -150,6 +153,7 @@ kernel.
     </tr>
     {% assign prev_vendor_name = sensor.vendor_name %}
 {% endfor %}
+    </tbody>
 </table>
 
 

--- a/docs/sensors/index.md
+++ b/docs/sensors/index.md
@@ -126,7 +126,7 @@ kernel.
                 {% assign vendor_name_rowspan = vendor_name_rowspan | plus: 1 %}
             {% endif %}
         {% endfor %}
-        <td rowspan="{{ vendor_name_rowspan }}">{{ sensor.vendor_name }}</td>
+        <th rowspan="{{ vendor_name_rowspan }}">{{ sensor.vendor_name }}</th>
     {% endif %}
         <td>{{ sensor.vendor_part_number }}</td>
         <td><a href="{{ sensor.url_name }}">{{ sensor.vendor_part_name }}</a></td>

--- a/index.md
+++ b/index.md
@@ -40,7 +40,7 @@ jumbotron-content: |
       </p>
       <p>
           Just like you can take apart your LEGO<sup>&reg;</sup> models and build something
-          completely different, we have reversed-engineered the EV3 and created
+          completely different, we have reverse-engineered the EV3 and created
           a new software platform for programming your robots.
       </p>
   </div>

--- a/stylesheets/bootstrap-extensions.css
+++ b/stylesheets/bootstrap-extensions.css
@@ -131,3 +131,7 @@ sup[id]:before {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
 }
+
+.table-indexed th {
+    background-color: #3d3d3d;
+}

--- a/stylesheets/bootstrap-extensions.css
+++ b/stylesheets/bootstrap-extensions.css
@@ -132,6 +132,15 @@ sup[id]:before {
     border-bottom-left-radius: 4px;
 }
 
-.table th {
+.table-indexed > tbody th {
     background-color: #2f2f2f;
+}
+
+.table-indexed > thead > tr,
+.table-indexed > tbody > tr:nth-of-type(2n+0) {
+    background-color: #3d3d3d;
+}
+
+.table-indexed > tbody > tr:nth-of-type(2n+1) {
+    background-color: transparent;
 }

--- a/stylesheets/bootstrap-extensions.css
+++ b/stylesheets/bootstrap-extensions.css
@@ -133,5 +133,5 @@ sup[id]:before {
 }
 
 .table th {
-    background-color: #3d3d3d;
+    background-color: #2f2f2f;
 }

--- a/stylesheets/bootstrap-extensions.css
+++ b/stylesheets/bootstrap-extensions.css
@@ -132,6 +132,6 @@ sup[id]:before {
     border-bottom-left-radius: 4px;
 }
 
-.table-indexed th {
+.table th {
     background-color: #3d3d3d;
 }


### PR DESCRIPTION
See discussion in ev3dev/ev3dev#437.

This should include fixes for the issues pointed out in comments -- let me know if I missed anything.

I updated the sensor and motor pages to replace the `<td>`s with `<th>`s for the row headers that span multiple items. If there are any other pages that have similar row/column span settings in tables, we'll need to update those too to make them adopt the new style.

(Fixes ev3dev/ev3dev#437) -- this should close the other issue when you merge this.