### PR TITLE
Remove BOM from head template

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,4 @@
-﻿<head>
+<head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
I noticed a while ago that browser dev tools would complain about our markup structure pretty much universally. I hadn't taken the time to look into it until now, but it turns out that A UTF-8 BOM was introduced into our head template and was causing some browsers to complain about the `<head>` tag. This PR should remove that and fix the issue.