### PR TITLE
Add new platform selection mechanism

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -27,6 +27,7 @@
     <script src="{{ site.github.url }}/javascripts/search.js"></script>
     <!-- Converts static descriptors of tab target content into live text and links -->
     <script src="{{ site.github.url }}/javascripts/tabs.js"></script>
+    <script src="{{ site.github.url }}/javascripts/platform-select.js"></script>
     <!-- Adds classes and other styles to pages where hard-coded css can't be used -->
     <script src="{{ site.github.url }}/javascripts/style-helpers.js"></script>
 

--- a/docs/tutorials/platform-test-page.md
+++ b/docs/tutorials/platform-test-page.md
@@ -1,0 +1,37 @@
+---
+title: Platform test page
+subject: Website
+---
+
+This is a test page.
+
+*   {: data-platform-attribute-value="Android"}
+    1.  This is the first step for Android.
+
+    2.  This is the second step for Android.
+
+*   {: data-platform-attribute-value="Mac OSX"}
+
+    1.  Another step! This one's for Mac.
+
+    2.  ...And another for Mac.
+
+*   {: data-platform-attribute-value="Ubuntu"}
+
+    1.  Even more steps! Now featuring 100% more Ubuntu.
+
+    2.  Steps continued.
+
+*   {: data-platform-attribute-value="Windows"} I give up. Just imagine there are steps here.
+{: data-platform-select-list-attribute="client-platform" }
+
+*   {: data-platform-attribute-value="EV3 Brick"}
+    On the EV3, do a thing in this specific way.
+
+*   {: data-platform-attribute-value="BrickPi"}
+    The BrickPi is a little different. You actually need to do this other thing.
+
+*   {: data-platform-attribute-value="PiStorms"}
+    The PiStorms doesn't support this portion of the functionality.
+    You need to take this into consideration.
+{: data-platform-select-list-attribute="ev3dev-hardware-platform" }

--- a/javascripts/platform-select.js
+++ b/javascripts/platform-select.js
@@ -1,0 +1,118 @@
+function supportsHtml5Storage() {
+    try {
+        return 'localStorage' in window && window['localStorage'] !== null;
+    } catch (e) {
+        return false;
+    }
+}
+
+function cleanTextForId(text) {
+    return text.replace(/\W+/g, '-');
+}
+
+function getFilterByData(dataHash) {
+    if(arguments.length == 2) {
+        var newHash = {};
+        newHash[arguments[0]] = arguments[1];
+        dataHash = newHash;
+    }
+    
+    return function () {
+        var currentTarget = $(this);
+        return Object.keys(dataHash).every(function(property) {
+            return currentTarget.data(property) == dataHash[property];
+        });
+    }
+}
+
+function switchSelectedPlatformAttribute(platformAttributeName, newAttributeValue) {
+    // Containers of platform content should have .platform-content-item
+    // Containers of platform content should have data-platform-attribute-name and data-platform-attribute-value
+    $('.platform-content-item')
+        .filter(getFilterByData('platform-attribute-name', platformAttributeName))
+        .hide()
+        .filter(getFilterByData('platform-attribute-value', newAttributeValue))
+        .show();
+    
+    $('.platform-attribute-select-group')
+        .filter(getFilterByData('target-platform-attribute-name', platformAttributeName))
+        .children()
+        .removeClass('active')
+        .filter(getFilterByData('platform-attribute-value', newAttributeValue))
+        .addClass('active');
+    
+    // TODO: Save current option to local storage
+}
+
+function addPlatformNavItem(platformAttributeName, newAttributeValue) {    
+    // Container for pills should have .platform-attribute-select-group and data-target-platform-attribute-name
+    var $platNav = $('.platform-attribute-select-group')
+        .filter(getFilterByData('target-platform-attribute-name', platformAttributeName));
+
+    if ($platNav.length <= 0) {
+        $platNav = $('<ul class="nav nav-pills platform-attribute-select-group"/>')
+            .data('target-platform-attribute-name', platformAttributeName);
+        $platNav.insertAfter($('.page-header'));
+    }
+    else if($platNav.children().filter(getFilterByData('platform-attribute-value', newAttributeValue)).length > 0) {
+        // If there are any pills that have already been created for this value, we are done
+        return;
+    }
+
+    var $pillItem = $('<li/>')
+        .data('platform-attribute-value', newAttributeValue)
+        .addClass('platform-select-link');
+        
+    // TODO: Use text lookup and data file
+    $('<a/>').text(newAttributeValue).appendTo($pillItem);
+
+    $pillItem.click(function () {
+        switchSelectedPlatformAttribute(platformAttributeName, newAttributeValue);
+    })
+
+    $platNav.append($pillItem);
+}
+
+$(document).ready(function () {    
+    $('ul[data-platform-select-list-attribute]').each(function (i, platformUl) {
+        var $platformUl = $(platformUl);
+        var targetAttribute = $platformUl.data('platform-select-list-attribute');
+        
+        var $platformContentContainer = $('<div/>');
+        $platformContentContainer.insertBefore($platformUl);
+
+        $platformUl.detach();
+        
+        $platformUl.children('li[data-platform-attribute-value]').each(function (i, platformLi) {
+            var $platformLi = $(platformLi);
+            var currentPlatformAttributeValue = $platformLi.data('platform-attribute-value');
+
+            var $newPlatformContentItem = $('<div/>').addClass("platform-content-item");
+            $newPlatformContentItem.attr('id', 'plat-' + cleanTextForId(targetAttribute) + '-' + cleanTextForId(currentPlatformAttributeValue));
+            $newPlatformContentItem.data({
+                'platform-attribute-name': targetAttribute,
+                'platform-attribute-value': currentPlatformAttributeValue
+            });
+
+            $newPlatformContentItem.append($platformLi.contents().detach());
+            $newPlatformContentItem.appendTo($platformContentContainer);
+
+            addPlatformNavItem(targetAttribute, currentPlatformAttributeValue);
+        });
+
+        // TODO: Add ability to nest options (as dropdown)
+    });
+    
+    $('.platform-attribute-select-group').each(function() {
+        var attributeName = $(this).data('target-platform-attribute-name');
+        // TODO: URL param
+        // TODO: lookup UA string
+        // TODO: HTML storage
+        
+        var defaultValue = $(this)
+            .children(':first')
+            .data('platform-attribute-value');
+        
+        switchSelectedPlatformAttribute(attributeName, defaultValue);
+    })
+});


### PR DESCRIPTION
Realization of ev3dev/ev3dev#474.

This is still WIP at the moment, so don't merge it (or look at it expecting it to be useful). But I have implemented the core of what was discussed in the issue linked above, so I figured I'd open this PR so that it can be discussed.

This just includes the basic JS needed to do the page content transformations and a test page that demonstrates the features. The code was originally a copy of the tab code, but as you can probably tell it has diverged to the point where there is very little resemblance (although the first 4 lines are _mostly_ unchanged :wink:). I also removed some functionality that I haven't yet reimplemented -- those items (and some others) are listed below. It also includes some notes-to-self and misc TODOs which will be cleaned up and removed in the future.

You can see the live test page [here](http://wasabifan.github.io/ev3dev.github.io/docs/tutorials/platform-test-page/).

Still unfinished:
- Nested attributes (for versions)
- Saving/loading previous selections
- Detecting platform options
- Formatting the options on the page with a flyout and whatever else
- Updating real pages