### PR TITLE
Better internal links

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,6 +12,11 @@
     <link rel="stylesheet" href="{{ internal-link-base }}/stylesheets/bootstrap-extensions.css">
     <!-- Nav infrastructure and misc utils (search, user cards, embeds, CC license) -->
     <link rel="stylesheet" href="{{ internal-link-base }}/stylesheets/infrastructure-utils.css" />
+    
+    <!-- Page-specific variable that indicates the relative path to the site root -->
+    <script>
+        var pageLinkBaseUrl = "{{internal-link-base}}";
+    </script>
 
     <!-- 3rd-party libraries -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,31 +4,31 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title>{{ page.title }}</title>
-    <link rel="alternate" type="application/atom+xml" href="{{ site.github.url }}/news/atom.xml" title="Atom feed">
+    <link rel="alternate" type="application/atom+xml" href="{{ internal-link-base }}/news/atom.xml" title="Atom feed">
     <link rel="icon" href="favicon.ico" />
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="{{ site.github.url }}/stylesheets/bootstrap.css">
-    <link rel="stylesheet" href="{{ site.github.url }}/stylesheets/bootstrap-extensions.css">
+    <link rel="stylesheet" href="{{ internal-link-base }}/stylesheets/bootstrap.css">
+    <link rel="stylesheet" href="{{ internal-link-base }}/stylesheets/bootstrap-extensions.css">
     <!-- Nav infrastructure and misc utils (search, user cards, embeds, CC license) -->
-    <link rel="stylesheet" href="{{ site.github.url }}/stylesheets/infrastructure-utils.css" />
+    <link rel="stylesheet" href="{{ internal-link-base }}/stylesheets/infrastructure-utils.css" />
 
     <!-- 3rd-party libraries -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-    <script src="{{ site.github.url }}/javascripts/jquery.getUrlParam.js"></script>
-    <script src="{{ site.github.url }}/javascripts/jquery.loadTemplate-1.4.4.min.js"></script>
-    <script src="{{ site.github.url }}/javascripts/respond.js"></script>
-    <script src="{{ site.github.url }}/javascripts/ua-parser.min.js"></script>
+    <script src="{{ internal-link-base }}/javascripts/jquery.getUrlParam.js"></script>
+    <script src="{{ internal-link-base }}/javascripts/jquery.loadTemplate-1.4.4.min.js"></script>
+    <script src="{{ internal-link-base }}/javascripts/respond.js"></script>
+    <script src="{{ internal-link-base }}/javascripts/ua-parser.min.js"></script>
 
     <!-- Loads user-cards from GH API -->
-    <script src="{{ site.github.url }}/javascripts/cards.js"></script>
+    <script src="{{ internal-link-base }}/javascripts/cards.js"></script>
     <!-- Responds to queries typed into the "Quick nav" box -->
-    <script src="{{ site.github.url }}/javascripts/search.js"></script>
+    <script src="{{ internal-link-base }}/javascripts/search.js"></script>
     <!-- Converts static descriptors of tab target content into live text and links -->
-    <script src="{{ site.github.url }}/javascripts/tabs.js"></script>
+    <script src="{{ internal-link-base }}/javascripts/tabs.js"></script>
     <!-- Adds classes and other styles to pages where hard-coded css can't be used -->
-    <script src="{{ site.github.url }}/javascripts/style-helpers.js"></script>
+    <script src="{{ internal-link-base }}/javascripts/style-helpers.js"></script>
 
     <!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,14 +7,14 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="{{ site.github.url }}/">
-                    <img id="brand-logo" src="{{ site.github.url }}/images/ev3dev_logo_white.png" />
+                <a class="navbar-brand" href="{{ internal-link-base }}/">
+                    <img id="brand-logo" src="{{ internal-link-base }}/images/ev3dev_logo_white.png" />
                 </a>
             </div>
             <div class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
                     <li>
-                        <a href="{{ site.github.url }}/" title="There's no place like Home...">Home</a>
+                        <a href="{{ internal-link-base }}/" title="There's no place like Home...">Home</a>
                     </li>
                     <li class="dropdown">
                         <a class="dropdown-toggle" data-toggle="dropdown" title="Documentation on how to use ev3dev">
@@ -23,26 +23,26 @@
                         </a>
                         <ul class="dropdown-menu">
                             <li>
-                                <a href="{{ site.github.url }}/docs/getting-started">Getting Started</a>
+                                <a href="{{ internal-link-base }}/docs/getting-started">Getting Started</a>
                             </li>
                             <li>
-                                <a href="{{ site.github.url }}/docs/tutorials">Tutorials</a>
-                            </li>
-                            <li role="separator" class="divider"></li>
-                            <li>
-                                <a href="{{ site.github.url }}/docs/motors">Motors</a>
-                            </li>
-                            <li>
-                                <a href="{{ site.github.url }}/docs/sensors">Sensors</a>
+                                <a href="{{ internal-link-base }}/docs/tutorials">Tutorials</a>
                             </li>
                             <li role="separator" class="divider"></li>
                             <li>
-                                <a href="{{ site.github.url }}/docs">More...</a>
+                                <a href="{{ internal-link-base }}/docs/motors">Motors</a>
+                            </li>
+                            <li>
+                                <a href="{{ internal-link-base }}/docs/sensors">Sensors</a>
+                            </li>
+                            <li role="separator" class="divider"></li>
+                            <li>
+                                <a href="{{ internal-link-base }}/docs">More...</a>
                             </li>
                         </ul>
                     </li>
                     <li>
-                        <a href="{{ site.github.url }}/news" title="News about ev3dev">News</a>
+                        <a href="{{ internal-link-base }}/news" title="News about ev3dev">News</a>
                     </li>
                     <li class="dropdown">
                         <a class="dropdown-toggle" data-toggle="dropdown">
@@ -51,16 +51,16 @@
                         </a>
                         <ul class="dropdown-menu">
                             <li>
-                                <a href="{{ site.github.url }}/projects" title="Discover projects that use ev3dev">Projects</a>
+                                <a href="{{ internal-link-base }}/projects" title="Discover projects that use ev3dev">Projects</a>
                             </li>
                             <li>
-                                <a href="{{ site.github.url }}/share" title="Share projects that use ev3dev">Share</a>
+                                <a href="{{ internal-link-base }}/share" title="Share projects that use ev3dev">Share</a>
                             </li>
                             <li>
-                                <a href="{{ site.github.url }}/contribute" title="How to contribute to ev3dev">Contribute</a>
+                                <a href="{{ internal-link-base }}/contribute" title="How to contribute to ev3dev">Contribute</a>
                             </li>
                             <li>
-                                <a href="{{ site.github.url }}/support" title="Found a bug? Have a question?">Get Help</a>
+                                <a href="{{ internal-link-base }}/support" title="Found a bug? Have a question?">Get Help</a>
                             </li>
                         </ul>
                     </li>

--- a/_includes/inline-screenshot.html
+++ b/_includes/inline-screenshot.html
@@ -1,3 +1,4 @@
+{% include internal-link-base.html %}
 <div class="screenshot inline-screenshot pull-right">
 <a href="{{ internal-link-base }}{{ include.source }}">
 <img src="{{ internal-link-base }}{{ include.source }}" />

--- a/_includes/inline-screenshot.html
+++ b/_includes/inline-screenshot.html
@@ -1,6 +1,6 @@
 <div class="screenshot inline-screenshot pull-right">
-<a href="{{ site.github.url }}{{ include.source }}">
-<img src="{{ site.github.url }}{{ include.source }}" />
+<a href="{{ internal-link-base }}{{ include.source }}">
+<img src="{{ internal-link-base }}{{ include.source }}" />
 </a>
 <p>
 <small>

--- a/_includes/internal-link-base.html
+++ b/_includes/internal-link-base.html
@@ -1,0 +1,11 @@
+{% assign internal-link-base = '' %}
+{% assign depth = page.url | prepend: '_' | append: '_' | split: '/' | size | minus: 1 %}
+{% if    depth == 1 %}{% assign internal-link-base = '.' %}
+{% elsif depth == 2 %}{% assign internal-link-base = '..' %}
+{% else %}
+{% assign internal-link-base = '..' %}
+{% assign depth = depth | minus: 2 %}
+{% for i in (1..depth) %}
+    {% assign internal-link-base = internal-link-base | append: '/..' %}
+{% endfor %}
+{% endif %}

--- a/_includes/internal-link-base.html
+++ b/_includes/internal-link-base.html
@@ -1,11 +1,13 @@
+{% capture throwaway-empty-whitespace %}
 {% assign internal-link-base = '' %}
 {% assign depth = page.url | prepend: '_' | append: '_' | split: '/' | size | minus: 1 %}
 {% if    depth == 1 %}{% assign internal-link-base = '.' %}
 {% elsif depth == 2 %}{% assign internal-link-base = '..' %}
 {% else %}
-{% assign internal-link-base = '..' %}
-{% assign depth = depth | minus: 2 %}
-{% for i in (1..depth) %}
-    {% assign internal-link-base = internal-link-base | append: '/..' %}
-{% endfor %}
+    {% assign internal-link-base = '..' %}
+    {% assign depth = depth | minus: 2 %}
+    {% for i in (1..depth) %}
+        {% assign internal-link-base = internal-link-base | append: '/..' %}
+    {% endfor %}
 {% endif %}
+{% endcapture %}

--- a/_includes/screenshot.html
+++ b/_includes/screenshot.html
@@ -7,4 +7,4 @@ Parameters:
 source: The url of the image
 caption: (optional) A caption that is displayed under the image.
 
-{% endcomment %}{% assign url = include.source %}{% assign first_char = url | first %}{%if first == '/' %}{% assign url = site.github.url | append: url %}{% endif %}<span class="screenshot"><a href="{{ site.github.url }}{{ include.source }}"><img src="{{ url }}" alt="screenshot" class="img-responsive" /></a>{% if include.caption %}<p><small>{{ include.caption }}</small></p>{% endif %}</span>
+{% endcomment %}{% assign url = include.source %}{% assign first_char = url | first %}{%if first == '/' %}{% assign url = internal-link-base | append: url %}{% endif %}<span class="screenshot"><a href="{{ internal-link-base }}{{ include.source }}"><img src="{{ url }}" alt="screenshot" class="img-responsive" /></a>{% if include.caption %}<p><small>{{ include.caption }}</small></p>{% endif %}</span>

--- a/_includes/title.html
+++ b/_includes/title.html
@@ -17,7 +17,7 @@
         {% if edit_path %}
             <a class="btn btn-primary pull-right" href="{{ edit_path }}">Edit on Github</a>
         {% elsif show_news_link %}
-            <a class="btn btn-primary pull-right" href="{{ site.github.url }}/news/atom.xml">Subscribe via Atom</a>
+            <a class="btn btn-primary pull-right" href="{{ internal-link-base }}/news/atom.xml">Subscribe via Atom</a>
         {% endif %}
     </h1>
 </div>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 ---
-
+{% include internal-link-base.html %}
 <hr />
 <div class="nav-dropdown-arrow">
     <div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,6 +3,7 @@
 ---
 
 <!doctype html>
+{% include internal-link-base.html %}
 <html>
 {% include head.html %}
 {% if page.jumbotron-heading or page.jumbotron-content %}

--- a/contribute.md
+++ b/contribute.md
@@ -37,7 +37,7 @@ links works and the information is still relevant.
 As the hardware drivers are being finalized, development will be shifting to
 software that can interface with the hardware. There are many [packages on
 GitHub][ev3dev-github-org] that you can hack on. Additionally, there are some
-language bindings listed on the [home page](/) that are not part of the ev3dev
+language bindings listed on the [libraries page]({{ internal-link-base }}/docs/libraries) that are not part of the ev3dev
 GitHub organization (yet).
 
 If you have never used GitHub before, it's super-easy. [Read about it][GitHub Help],

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -228,7 +228,7 @@ Here are some guides for using each of the major components.
 There are a number of programming languages available to use. The brick can
 run almost all languages that any other Linux distro can, so your favorite
 language is probably supported. Language bindings have already been written
-for many languages. You can learn more about the available libraries [here](/docs/libraries).
+for many languages. You can learn more about the available libraries [here]({{ internal-link-base }}/docs/libraries).
 
 If the language you want isn't listed, you still can use it, but you'll have to
 do more of the heavy lifting yourself using the guides above. Once you get the

--- a/docs/tutorials/adding-new-project.md
+++ b/docs/tutorials/adding-new-project.md
@@ -132,7 +132,7 @@ to submit your changes.
 The project maintainers will be notified automatically that you have submitted
 edits, and will review and merge your changes when they get the chance.
 
-[projects page]: {{ site.github.url }}/projects
+[projects page]: {{ internal-link-base }}/projects
 [mindsensor.com]: http://mindsensors.com/
 [projects folder]: https://github.com/ev3dev/ev3dev.github.io/tree/master/projects/_posts
 [kramdown basics]: http://kramdown.gettalong.org/quickref.html

--- a/docs/tutorials/adding-new-project.md
+++ b/docs/tutorials/adding-new-project.md
@@ -3,6 +3,8 @@ title: Adding a New Project
 subject: This Website
 ---
 
+{% include internal-link-base.html %}
+
 We currently have a [projects page] where you can browse projects that have
 been built using ev3dev. You can add your own too!  Each project gets a
 dedicated page for the author to explain what they have been working on, as

--- a/docs/tutorials/index.html
+++ b/docs/tutorials/index.html
@@ -1,7 +1,7 @@
 ---
 title: Tutorials
 ---
-
+{% include internal-link-base.html %}
 {% assign tutorials=site.pages | where: "category", "tutorials" | sort: "subject" | group_by: "subject" %}
 
 <div class="row">
@@ -15,7 +15,7 @@ title: Tutorials
                         {% assign items = group.items | sort: "title" %}
                         {% for item in items %}
                         <li>
-                            <a href="{{internal-link-base}}{{ item.url }}">{{ item.title }}</a>
+                            <a href="{{ internal-link-base }}{{ item.url }}">{{ item.title }}</a>
                             {% if item.subtitle %}
                                 ({{ item.subtitle }})
                             {% endif %}

--- a/docs/tutorials/index.html
+++ b/docs/tutorials/index.html
@@ -15,7 +15,7 @@ title: Tutorials
                         {% assign items = group.items | sort: "title" %}
                         {% for item in items %}
                         <li>
-                            <a href="{{site.github.url}}{{ item.url }}">{{ item.title }}</a>
+                            <a href="{{internal-link-base}}{{ item.url }}">{{ item.title }}</a>
                             {% if item.subtitle %}
                                 ({{ item.subtitle }})
                             {% endif %}

--- a/docs/tutorials/nxtmmx.md
+++ b/docs/tutorials/nxtmmx.md
@@ -2,6 +2,7 @@
 title: Using the mindsensors.com NxtMMX Motor Controller
 subject: Hardware - Motors
 ---
+{% include internal-link-base.html %}
 
 The [mindsensors.com NxtMMX] motor controller uses the [tacho-motor class], so
 most of the information in the [tahco-motor tutorial] is applicable. However,

--- a/docs/tutorials/nxtmmx.md
+++ b/docs/tutorials/nxtmmx.md
@@ -42,6 +42,6 @@ Example - set Pass Count to 10:
 
     $ echo -e -n "\x$(printf '%x' 10)" | dd bs=1 of=direct seek=0x86
 
-[mindsensors.com NxtMMX]: {{ site.github.url }}/docs/sensors/mindsensors.com-multiplexer-for-nxt-ev3-motors
-[tacho-motor class]: {{ site.github.url }}/docs/drivers/tacho-motor-class
+[mindsensors.com NxtMMX]: {{ internal-link-base }}/docs/sensors/mindsensors.com-multiplexer-for-nxt-ev3-motors
+[tacho-motor class]: {{ internal-link-base }}/docs/drivers/tacho-motor-class
 [tahco-motor tutorial]: ../tacho-motors

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -76,7 +76,7 @@ function loadSearchData(callback) {
         return;
 
     dataLoading = true;
-    $.getJSON("../../search-index.json", function (e) {
+    $.getJSON(pageLinkBaseUrl + "/search-index.json", function (e) {
         dataLoading = false;
         searchData = e.slice(0, -1);
 

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -76,7 +76,7 @@ function loadSearchData(callback) {
         return;
 
     dataLoading = true;
-    $.getJSON("{{ site.github.url }}/search-index.json", function (e) {
+    $.getJSON("../../search-index.json", function (e) {
         dataLoading = false;
         searchData = e.slice(0, -1);
 
@@ -175,6 +175,9 @@ function doSearch(query) {
         else if (categoryTags.indexOf('news') != -1)
             resultArea = newsResultArea;
 
+        // NOTE: Links are taken as-is from the search index. These links are relative to the
+        // website root, so they start with "/". This means that they won't resolve over file://
+        // or other protocols that don't use the site root as the URL root.
         resultArea.loadTemplate($('#search-result-template'), results[i], { append: true });
 
         resultArea.children().last().show(20);

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -174,11 +174,11 @@ function doSearch(query) {
             resultArea = projectResultArea;
         else if (categoryTags.indexOf('news') != -1)
             resultArea = newsResultArea;
-
-        // NOTE: Links are taken as-is from the search index. These links are relative to the
-        // website root, so they start with "/". This means that they won't resolve over file://
-        // or other protocols that don't use the site root as the URL root.
-        resultArea.loadTemplate($('#search-result-template'), results[i], { append: true });
+        
+        var searchResultObj = $.extend({}, results[i]);
+        searchResultObj.href = pageLinkBaseUrl + searchResultObj.href;
+        
+        resultArea.loadTemplate($('#search-result-template'), searchResultObj, { append: true });
 
         resultArea.children().last().show(20);
 

--- a/news/_posts/2014-12-31-Introducing-the-News-Feed.md
+++ b/news/_posts/2014-12-31-Introducing-the-News-Feed.md
@@ -4,4 +4,4 @@ author: "@ev3dev"
 
 This is the first post in a hopefully long series of posts in our new ev3dev news feed. Here we plan to post about things like release announcements, as well as any other news-worthy events.
 
-Along with the page on our site, our new [atom news feed]({{ site.github.url }}/news/atom.xml) will maintain a listing of these posts.
+Along with the page on our site, our new [atom news feed]({{ internal-link-base }}/news/atom.xml) will maintain a listing of these posts.

--- a/news/_posts/2014-12-31-Introducing-the-News-Feed.md
+++ b/news/_posts/2014-12-31-Introducing-the-News-Feed.md
@@ -2,6 +2,8 @@
 author: "@ev3dev"
 ---
 
+{% include internal-link-base.html %}
+
 This is the first post in a hopefully long series of posts in our new ev3dev news feed. Here we plan to post about things like release announcements, as well as any other news-worthy events.
 
 Along with the page on our site, our new [atom news feed]({{ internal-link-base }}/news/atom.xml) will maintain a listing of these posts.

--- a/news/_posts/2015-04-15-Kernel-Release-v3.16.7-ckt9-ev3dev1.md
+++ b/news/_posts/2015-04-15-Kernel-Release-v3.16.7-ckt9-ev3dev1.md
@@ -26,9 +26,9 @@ see what else changed.
 This kernel also includes the latest upstream patches. See [ckt7-changelog],
 [ckt8-changelog] and [ckt9-changelog].
 
-[nxtmmx]: {{ site.github.url }}/docs/sensors/mindsensors.com-multiplexer-for-nxt-ev3-motors/
-[tacho-motor tutorial]: {{ site.github.url }}/docs/tutorials/tacho-motors
-[tacho-motor-class]: {{ site.github.url }}/docs/drivers/tacho-motor-class
+[nxtmmx]: {{ internal-link-base }}/docs/sensors/mindsensors.com-multiplexer-for-nxt-ev3-motors/
+[tacho-motor tutorial]: {{ internal-link-base }}/docs/tutorials/tacho-motors
+[tacho-motor-class]: {{ internal-link-base }}/docs/drivers/tacho-motor-class
 [issue #282]: https://github.com/ev3dev/ev3dev/issues/282
 [ckt7-changelog]: https://lists.ubuntu.com/archives/kernel-team/2015-February/054674.html
 [ckt8-changelog]: https://lists.ubuntu.com/archives/kernel-team/2015-March/055191.html

--- a/news/_posts/2015-04-15-Kernel-Release-v3.16.7-ckt9-ev3dev1.md
+++ b/news/_posts/2015-04-15-Kernel-Release-v3.16.7-ckt9-ev3dev1.md
@@ -2,6 +2,7 @@
 author: "@dlech"
 title: "Kernel Release: v3.16.7-ckt9-ev3dev1/dkms3.0"
 ---
+{% include internal-link-base.html %}
 
 Kernel version 3.16.7-ckt9-ev3dev1 has been released. This release contains a
 major overhaul of the tacho-motor class. There are lots of breaking changes,

--- a/news/_posts/2015-07-08-ev3-ev3dev-jessie-2015-07-08-release.md
+++ b/news/_posts/2015-07-08-ev3-ev3dev-jessie-2015-07-08-release.md
@@ -2,6 +2,7 @@
 author: "@dlech"
 title: "Image release ev3-ev3dev-jessie-2015-07-08"
 ---
+{% include internal-link-base.html %}
 
 This image release contains updated packages from the previous
 ev3dev-jessie-2015-05-20 release, including packages from the Debian 8.1 point

--- a/news/_posts/2015-07-08-ev3-ev3dev-jessie-2015-07-08-release.md
+++ b/news/_posts/2015-07-08-ev3-ev3dev-jessie-2015-07-08-release.md
@@ -17,5 +17,5 @@ you need to install a new image because of some [major changes].
 
 [Download]: https://github.com/ev3dev/ev3dev/releases/tag/ev3-ev3dev-jessie-2015-07-08
 [release notes]: https://github.com/ev3dev/ev3dev/blob/master/release-notes/ev3-ev3dev-jessie-2015-07-08.img-release-notes.md
-[ev3dev kernel]: {{ site.github.url }}/news/2015/07/08/Kernel-Release-v3.16.7-ckt11-5-ev3dev-ev3
-[major changes]: {{ site.github.url }}/news/2015/05/01/Major-Release
+[ev3dev kernel]: {{ internal-link-base }}/news/2015/07/08/Kernel-Release-v3.16.7-ckt11-5-ev3dev-ev3
+[major changes]: {{ internal-link-base }}/news/2015/05/01/Major-Release

--- a/news/_posts/2015-09-13-ev3-ev3dev-jessie-2015-09-13-release.md
+++ b/news/_posts/2015-09-13-ev3-ev3dev-jessie-2015-09-13-release.md
@@ -2,6 +2,7 @@
 author: "@dlech"
 title: "Image release ev3-ev3dev-jessie-2015-09-13"
 ---
+{% include internal-link-base.html %}
 
 This image release contains updated packages from the previous
 ev3dev-jessie-2015-07-08 release, including packages from the Debian 8.2 point

--- a/news/_posts/2015-09-13-ev3-ev3dev-jessie-2015-09-13-release.md
+++ b/news/_posts/2015-09-13-ev3-ev3dev-jessie-2015-09-13-release.md
@@ -17,5 +17,5 @@ you need to install a new image because of some [major changes].
 
 [Download]: https://github.com/ev3dev/ev3dev/releases/tag/ev3-ev3dev-jessie-2015-09-13
 [release notes]: https://github.com/ev3dev/ev3dev/blob/master/release-notes/ev3-ev3dev-jessie-2015-09-13.img-release-notes.md
-[ev3dev kernel]: {{ site.github.url }}/news/2015/09/06/Kernel-Release-v3.16.7-ckt16-7-ev3dev-ev3
-[major changes]: {{ site.github.url }}/news/2015/05/01/Major-Release
+[ev3dev kernel]: {{ internal-link-base }}/news/2015/09/06/Kernel-Release-v3.16.7-ckt16-7-ev3dev-ev3
+[major changes]: {{ internal-link-base }}/news/2015/05/01/Major-Release

--- a/news/archive/index.html
+++ b/news/archive/index.html
@@ -8,7 +8,7 @@ title: News Archive
     {% if post.categories contains "news" %}
     <div class="news-item">
         <div class="news-item-header">
-            <h2><a href="{{ site.github.url }}{{ post.url }}">{{ post.title }}</a></h2>
+            <h2><a href="{{ internal-link-base }}{{ post.url }}">{{ post.title }}</a></h2>
             <hr/>
         </div>
     </div>

--- a/news/archive/index.html
+++ b/news/archive/index.html
@@ -2,7 +2,7 @@
 layout: page
 title: News Archive
 ---
-
+{% include internal-link-base.html %}
 
 {% for post in site.posts %}
     {% if post.categories contains "news" %}

--- a/news/atom.xml
+++ b/news/atom.xml
@@ -4,12 +4,11 @@ layout:
 ---
 <?xml version="1.0"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
- 
   <title>ev3dev News Feed</title>
-  <link href="{{ site.github.url }}"/>
+  <link href="{{ internal-link-base }}"/>
   <link type="application/atom+xml" rel="self" href="{{ site.github.url }}/news/atom.xml"/>
   <updated>{{ site.time | date_to_rfc822 }}</updated>
-  <id>{{ site.github.url }}/news/atom.xml</id>
+  <id>{{ internal-link-base }}/news/atom.xml</id>
   <author>
     <name>The ev3dev team</name>
   </author>
@@ -17,7 +16,7 @@ layout:
   {% for post in site.posts %}
   {% if post.categories contains "news" %}
   <entry>
-    <id>{{ site.github.url }}{{ post.id }}</id>
+    <id>{{ internal-link-base }}{{ post.id }}</id>
     <link type="text/html" rel="alternate" href="{{ site.github.url }}{{ post.url }}"/>
     <title>{{ post.title | xml_escape }}</title>
     <updated>{{ post.date | date_to_rfc822 }}</updated>

--- a/news/atom.xml
+++ b/news/atom.xml
@@ -8,7 +8,7 @@ layout:
   <link href="{{ internal-link-base }}"/>
   <link type="application/atom+xml" rel="self" href="{{ site.github.url }}/news/atom.xml"/>
   <updated>{{ site.time | date_to_rfc822 }}</updated>
-  <id>{{ internal-link-base }}/news/atom.xml</id>
+  <id>{{ site.github.url }}/news/atom.xml</id>
   <author>
     <name>The ev3dev team</name>
   </author>
@@ -16,7 +16,7 @@ layout:
   {% for post in site.posts %}
   {% if post.categories contains "news" %}
   <entry>
-    <id>{{ internal-link-base }}{{ post.id }}</id>
+    <id>{{ site.github.url }}{{ post.id }}</id>
     <link type="text/html" rel="alternate" href="{{ site.github.url }}{{ post.url }}"/>
     <title>{{ post.title | xml_escape }}</title>
     <updated>{{ post.date | date_to_rfc822 }}</updated>

--- a/news/index.html
+++ b/news/index.html
@@ -2,6 +2,7 @@
 title: News
 subtitle: Announcements and updates
 ---
+{% include internal-link-base.html %}
 
 {% for post in site.posts reversed %}
     {% if post.categories contains "news" %}

--- a/news/index.html
+++ b/news/index.html
@@ -12,7 +12,7 @@ subtitle: Announcements and updates
 <div class="panel panel-default">
     <div class="panel-heading">
         <h1 class="panel-title">
-            <a href="{{ site.github.url }}{{ first_post.url }}"> {{ first_post.title }}</a>
+            <a href="{{ internal-link-base }}{{ first_post.url }}"> {{ first_post.title }}</a>
             <span class="pull-right label font-light">{{ first_post.date | date_to_string }}</span>
         </h1>
     </div>
@@ -20,7 +20,7 @@ subtitle: Announcements and updates
         {{ first_post.content | truncatewords: 200 }}
         <br/>
         <br />
-        <a href="{{ site.github.url }}{{ first_post.url }}">Continue reading...</a>
+        <a href="{{ internal-link-base }}{{ first_post.url }}">Continue reading...</a>
     </div>
 </div>
 
@@ -32,7 +32,7 @@ subtitle: Announcements and updates
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <h1 class="panel-title">
-                        <a href="{{ site.github.url }}{{ post.url }}"> {{ post.title }}</a>
+                        <a href="{{ internal-link-base }}{{ post.url }}"> {{ post.title }}</a>
                         <span class="pull-right label font-light">{{ post.date | date_to_string }}</span>
                     </h1>
                 </div>
@@ -40,7 +40,7 @@ subtitle: Announcements and updates
                     {{ post.content | truncatewords: 50 }}
                     <br />
                     <br />
-                    <a href="{{ site.github.url }}{{ post.url }}">Continue reading...</a>
+                    <a href="{{ internal-link-base }}{{ post.url }}">Continue reading...</a>
                 </div>
             </div>
         {% endif %}
@@ -48,5 +48,5 @@ subtitle: Announcements and updates
 {% endfor %}
 
 <div class="row text-center">
-    <a class="btn btn-primary" href="{{ site.github.url }}/news/archive">See news archive for older posts</a>
+    <a class="btn btn-primary" href="{{ internal-link-base }}/news/archive">See news archive for older posts</a>
 </div>

--- a/projects/index.html
+++ b/projects/index.html
@@ -1,6 +1,7 @@
 ---
 title: Projects
 ---
+{% include internal-link-base.html %}
 
 <p class="lead">
     This is where we keep a collection of all the projects that people are working
@@ -29,7 +30,7 @@ title: Projects
                     {% endif %}
                     <div class="caption">
                         <h3>{{ post.title }}</h3>
-						<p>{{ post.excerpt | truncatewords: num_words }}</p>
+						<p>{{ post.excerpt | strip_html | truncatewords: num_words }}</p>
 						<p><a class="btn btn-primary" href="{{ internal-link-base }}{{ post.url }}">Learn more</a></p>
                     </div>
                 </div>

--- a/projects/index.html
+++ b/projects/index.html
@@ -11,7 +11,7 @@ title: Projects
 <div class="alert alert-info">
     {% include icon.html type="info" %}
     Would you like your project added to the list? We would!
-    <a class="alert-link" href="{{ site.github.url }}/docs/tutorials/adding-new-project/">Create a page and send us a pull request</a>.
+    <a class="alert-link" href="{{ internal-link-base }}/docs/tutorials/adding-new-project/">Create a page and send us a pull request</a>.
 </div>
 
 <div class="row">
@@ -23,14 +23,14 @@ title: Projects
                 <div class="thumbnail">
                     {% if post.youtube_video_id %}
 						{% assign num_words = 35 %}
-						<a href="{{ site.github.url }}{{ post.url }}">
+						<a href="{{ internal-link-base }}{{ post.url }}">
 							<img src="http://img.youtube.com/vi/{{post.youtube_video_id}}/mqdefault.jpg" />
 						</a>
                     {% endif %}
                     <div class="caption">
                         <h3>{{ post.title }}</h3>
 						<p>{{ post.excerpt | truncatewords: num_words }}</p>
-						<p><a class="btn btn-primary" href="{{ site.github.url }}{{ post.url }}">Learn more</a></p>
+						<p><a class="btn btn-primary" href="{{ internal-link-base }}{{ post.url }}">Learn more</a></p>
                     </div>
                 </div>
 			</div>

--- a/search-index.json
+++ b/search-index.json
@@ -5,7 +5,7 @@ layout:
     {% for post in site.posts %}
     {
       "title"    : "{{ post.title }}",
-        "href": "{{ site.github.url }}{{ post.url }}",
+        "href": "{{ post.url }}",
         "author":  "{{ post.author | join: ', ' }}",
         "date": "{{ post.date | date_to_long_string }}",
         "loopid" : "post-{{ forloop.index }}",
@@ -15,7 +15,7 @@ layout:
     {% for page in site.pages %}
     {
       "title"    : "{{ page.title }}",
-      "href"     : "{{ site.github.url }}{{ page.url }}",
+      "href"     : "{{ page.url }}",
       "loopid": "page-{{ forloop.index }}",
       "category": "{{ page.categories }}",
       {% assign parent_dirs=page.url | replace_first: '/', '' | split: '/' %}

--- a/share.md
+++ b/share.md
@@ -1,6 +1,8 @@
 ---
 title: Share
 ---
+{% include internal-link-base.html %}
+
 <div class="lead">
     <center>
         Do you like ev3dev? Show your support!

--- a/share.md
+++ b/share.md
@@ -31,7 +31,7 @@ well as provide videos, pictures, build instructions, code, and any other media
 that pertains to the project. If you have a project that you'd like to share,
 check out [the tutorial][Adding a new project].
 
-[projects page]: {{ site.github.url }}/projects
+[projects page]: {{ internal-link-base }}/projects
 [mindsensor.com]: http://mindsensors.com/
 [projects folder]: https://github.com/ev3dev/ev3dev.github.io/tree/master/projects/_posts
 [template project]: https://raw.githubusercontent.com/ev3dev/ev3dev.github.io/master/projects/_posts/2014-03-21-Example-Project.md


### PR DESCRIPTION
These changes replace the use of `site.github.url` with a new variable which is set in an include template. The template generates relative links, so we don't ever need to worry about where our stuff is: links will always resolve to the correct relative path.

This _would_ be a pretty elegant solution, but there's a caveat: while templates that are included into a page have access to variables declared on that page, content that is included in a layout does not. So this include needs to be on every content page where internal links are used.

This isn't great, but I think that it beats the alternative of either a) needing to manually edit URLs on dev machines because we always are redirected to the real site or b) being dependent on a specific URL structure that only works in some places. It _might_ be possible to do something like this with JS, but that brings with it many other issues and could be prone to errors.

Because I have changed so much stuff, **I would highly recommend not merging this directly**. Although I did my best to test key features such as search and the atom feed, I am around %90 sure that I broke and/or forgot something. So, I wanted to open this PR to make it easy to see just these changes; assuming @dlech is OK with the core of these modifications, I will squash and merge this branch into my CI branch so that it can run checks on every link on the site. Once I fix whatever errors show themselves, I expect that my CI changes will be happy. I will close this PR once we have come to a conclusion regarding usage of this new system.

Note to self: "Edit on GitHub" links should be updated to work in dev environment.
