### PR TITLE
fix news index page

### DIFF
--- a/news/index.html
+++ b/news/index.html
@@ -3,30 +3,9 @@ title: News
 subtitle: Announcements and updates
 ---
 
-{% for post in site.posts reversed %}
-    {% if post.categories contains "news" %}
-        {% assign first_post = post %}
-    {% endif %}
-{% endfor %}
-
-<div class="panel panel-default">
-    <div class="panel-heading">
-        <h1 class="panel-title">
-            <a href="{{ first_post.url }}"> {{ first_post.title }}</a>
-            <span class="pull-right label font-light">{{ first_post.date | date_to_string }}</span>
-        </h1>
-    </div>
-    <div class="panel-body">
-        {{ first_post.content | truncatewords: 200 }}
-        <br/>
-        <br />
-        <a href="{{ first_post.url }}">Continue reading...</a>
-    </div>
-</div>
-
 {% assign num_items = 5 %}
 {% for post in site.posts %}
-    {% if post.categories contains "news" and post.url != first_post.url %}
+    {% if post.categories contains "news" %}
         {% assign num_items = num_items | minus:1 %}
         {% if num_items >= 0 %}
             <div class="panel panel-default">
@@ -37,7 +16,7 @@ subtitle: Announcements and updates
                     </h1>
                 </div>
                 <div class="panel-body">
-                    {{ post.content | truncatewords: 50 }}
+                    {{ post.content | split: "<h" | first }}
                     <br />
                     <br />
                     <a href="{{ post.url }}">Continue reading...</a>


### PR DESCRIPTION
using truncate words was not good because it would truncate in the
middle of html tags and cause errors.

fixes #137 

The way this works is that it shows whatever if before the first heading. This isn't ideal for some of the existing posts, but going forward, we can always make sure to have a good introduction before the first heading.