### PR TITLE
Fix possibility of user names going under avatar images in cards

### DIFF
--- a/javascripts/cards.js
+++ b/javascripts/cards.js
@@ -7,10 +7,22 @@ $(document).ready(function () {
             $cardDiv = $cardDiv.children(':last-child')
 
             $cardDiv.append('<div class="user-card-avatar"><img src="' + userData.avatar_url + '"/></div>');
+            var $avatarDiv = $cardDiv.children(':last-child');
             $cardDiv.append('<div class="user-card-text"></div>');
             var $textDiv = $cardDiv.children(':last-child');
+            
             $textDiv.append('<div class="user-card-name">' + (userData.name || userData.login) + '</div>');
             $textDiv.append('<div class="user-card-login">@' + userData.login + '</div>');
+            
+            // Give the text a margin to make sure it does not go below the avatar
+            $avatarDiv.resize(function() {
+                $textDiv.css({
+                    width: 'auto',
+                    "margin-left": $avatarDiv.width()
+                });
+            });
+            
+            $avatarDiv.resize();
         });        
     });
 });


### PR DESCRIPTION
This is a small JavaScript helper that sets the text margin to a 'real' value that matches the avatar width. Without this, it is possible that user names that wrap to multiple lines would show up partially covered by user pictures. The JS only runs once in normal operation so it shouldn't slow down page operation at all.