### PR TITLE
Prevent content from being clipped by nav

### DIFF
--- a/index.md
+++ b/index.md
@@ -45,7 +45,7 @@ jumbotron-content: |
       </p>
   </div>
   <div class="col-lg-4">
-      <img class="img-responsive" src="images/logo_ev3dev_mono.png" alt="ev3dev boot logo" />
+      <img class="img-responsive" id="splash-thumbnail" src="images/logo_ev3dev_mono.png" alt="ev3dev boot logo" />
   </div>
 
 ---

--- a/stylesheets/landing-content.scss
+++ b/stylesheets/landing-content.scss
@@ -49,4 +49,8 @@
     .featurette {
         text-align: center;
     }
+    
+    #splash-thumbnail {
+        display: none;
+    }
 }

--- a/stylesheets/site-structure.scss
+++ b/stylesheets/site-structure.scss
@@ -57,14 +57,12 @@
 }
 
 // Body spacing
-body.no-jumbotron {
+body {
     padding-top: 40px;
 }
 
 @media (max-width: $screen-md-max) {
-    body.no-jumbotron {
         padding-top: 0;
-    }
 }
 
 // Panel title size


### PR DESCRIPTION
Also made splash screen thumbnail hidden on small screens to decrease wasted space on mobile.

Fixes #112.