### PR TITLE
Add meta descriptions with proper content on important pages

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,6 +4,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title>{{ page.title | xml_escape }}</title>
+    {% if page.excerpt %}
+    <meta name="description" content="{{ page.excerpt | remove: '<p>' | remove: '</p>' | strip }}"/>
+    {% else %}
+    <meta name="description" content="{{ page.title }}"/>
+    {% endif %}
     <link rel="alternate" type="application/atom+xml" href="/news/atom.xml" title="Atom feed">
     <link rel="icon" href="/favicon.ico" />
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,9 +5,9 @@
 
     <title>{{ page.title | xml_escape }}</title>
     {% if page.excerpt %}
-    <meta name="description" content="{{ page.excerpt | remove: '<p>' | remove: '</p>' | strip }}"/>
+    <meta name="description" content="{{ page.excerpt | strip_html | strip }}"/>
     {% else %}
-    <meta name="description" content="{{ page.title }}"/>
+    <!-- Description content not available -->
     {% endif %}
     <link rel="alternate" type="application/atom+xml" href="/news/atom.xml" title="Atom feed">
     <link rel="icon" href="/favicon.ico" />

--- a/contribute.md
+++ b/contribute.md
@@ -1,6 +1,7 @@
 ---
 title: Contribute
 redirect_from: /contributing/index.html
+excerpt: "ev3dev is a **HUGE** project and we are always happy to receive help. Here are some of the many ways you can contribute to the project."
 ---
 
 * Table of Contents

--- a/docs/devtools/setting-up-the-ev3dev-build-ecosystem.md
+++ b/docs/devtools/setting-up-the-ev3dev-build-ecosystem.md
@@ -1,5 +1,5 @@
 ---
-title: Setting Up The `ev3dev` Build Ecosystem
+title: Setting Up The ev3dev Build Ecosystem
 subject: Development Setup
 ---
 

--- a/docs/drivers/index.md
+++ b/docs/drivers/index.md
@@ -1,8 +1,9 @@
 ---
 title: Drivers
+excerpt: "Documentation for all of the device drivers included in the ev3dev kernel for EV3-specific hardware."
 ---
 
-These are all of the (documented) devices drivers included in the ev3dev
+These are all of the (documented) device drivers included in the ev3dev
 kernel for EV3-specific hardware. For mainline or other drivers, check out
 the [tutorials] or if nothing related is there, try searching the web.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,7 @@
 ---
 title: Getting Started with ev3dev
 categories: docs getting-started
+excerpt: "So you're ready to try out ev3dev. Great! Here are step-by-step instructions to help you get ev3dev up and running on your EV3 or Raspberry Pi."
 ---
 
 * Table of Contents

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,7 @@
 ---
 title: Documentation
 layout: page
+excerpt: "ev3dev documentation, tutorials, technical reference, getting started guides, and information on the underlying technologies."
 ---
 
 <div class="panel panel-info">

--- a/docs/kernel-hackers-notebook/index.md
+++ b/docs/kernel-hackers-notebook/index.md
@@ -1,5 +1,6 @@
 ---
 title: The Kernel Hacker's Notebook
+excerpt: "A technical reference about the things we have learned from working on the ev3dev kernel. It is mostly information about the hardware and device drivers."
 ---
 
 * Table of Contents

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -1,6 +1,7 @@
 ---
 title: Libraries
 subtitle: Pre-made language bindings that make accessing the EV3 device drivers easy
+excerpt: "If you are looking to write a program that takes advantage of the EV3's motors, sensors, or other native devices, using a language binding is the way to go."
 ---
 
 * Table of Contents

--- a/docs/motors/index.md
+++ b/docs/motors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Motors
 subtitle: And everything else that plugs into output ports on the EV3
+excerpt: "The EV3 has four output ports for connecting motors and other devices (like LEDs). If you are trying to use something that plugs into one of the output ports, read this guide."
 ---
 
 * Table of Contents

--- a/docs/ports/index.md
+++ b/docs/ports/index.md
@@ -1,6 +1,6 @@
 ---
 title: Input and Output Ports
-excerpt: "Documentation reference for the ports that one plugs sensors and motors into on the EV3 and their associated ev3dev drivers."
+excerpt: "Documentation reference for the input (sensor) and output (motor) port device drivers."
 ---
 
 This page is about the kind of ports that you plug [sensors] and [motors] into.

--- a/docs/ports/index.md
+++ b/docs/ports/index.md
@@ -1,5 +1,6 @@
 ---
 title: Input and Output Ports
+excerpt: "Documentation reference for the ports that one plugs sensors and motors into on the EV3 and their associated ev3dev drivers."
 ---
 
 This page is about the kind of ports that you plug [sensors] and [motors] into.

--- a/docs/sensors/index.md
+++ b/docs/sensors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sensors
 subtitle: And everything else that plugs into input ports on the EV3
+excerpt: "The EV3 has four input ports for connecting sensors and other devices (like sensor multiplexers or motor controllers). If you are trying to use something that plugs into one of the input ports, read this guide."
 ---
 
 * Table of Contents

--- a/docs/tutorials/index.html
+++ b/docs/tutorials/index.html
@@ -1,5 +1,6 @@
 ---
 title: Tutorials
+excerpt: "Tutorials on a wide range of ev3dev functionality, including networking, motor control, and usage of extra hardware."
 ---
 
 {% assign tutorials=site.pages | where: "category", "tutorials" | sort: "subject" | group_by: "subject" %}

--- a/index.md
+++ b/index.md
@@ -47,7 +47,7 @@ jumbotron-content: |
   <div class="col-lg-4">
       <img class="img-responsive" id="splash-thumbnail" src="images/logo_ev3dev_mono.png" alt="ev3dev boot logo" />
   </div>
-
+excerpt: "ev3dev is a Debian Linux-based operating system that runs on several LEGO MINDSTORMS compatible platforms including the LEGO MINDSTORMS EV3 and Raspberry Pi-powered BrickPi."
 ---
 <div class="container">
 

--- a/news/_posts/2016-01-25-evb-ev3dev-jessie-2016-01-25-release.md
+++ b/news/_posts/2016-01-25-evb-ev3dev-jessie-2016-01-25-release.md
@@ -1,6 +1,7 @@
 ---
 author: "@dlech"
 title: "Announcing Support for FatcatLab's EVB"
+excerpt: "Welcome to the family, BeagleBone! Starting today, we now support ev3dev on the BeagleBone with FatcatLab's EVB cape."
 ---
 
 Welcome to the family!

--- a/news/_posts/2016-04-11-Kernel-Release-Cycle-10.md
+++ b/news/_posts/2016-04-11-Kernel-Release-Cycle-10.md
@@ -1,6 +1,7 @@
 ---
 author: "@dlech"
 title: "Kernel Release Cycle 10"
+excerpt: "Kernel release cycle 10 is now available! In this release, we have included our newly-updated motor drivers as well as bug fixes for a few sensor and platform quirks."
 ---
 
 In this round of releases, we have:

--- a/news/index.html
+++ b/news/index.html
@@ -1,6 +1,7 @@
 ---
 title: News
 subtitle: Announcements and updates
+excerpt: "ev3dev release announcements, community updates, and other posts on noteworthy events. Check here or monitor our Atom feed to stay up-to-date on ev3dev news."
 ---
 
 {% assign num_items = 5 %}

--- a/projects/index.html
+++ b/projects/index.html
@@ -1,9 +1,10 @@
 ---
 title: Projects
+excerpt: "This is where we keep a collection of some of the projects that people are working on using ev3dev. We invite you to click through the links below to see what cool stuff ev3dev can do!"
 ---
 
 <p class="lead">
-    This is where we keep a collection of all the projects that people are working
+    This is where we keep a collection of some of the projects that people are working
     on using ev3dev. We invite you to click through the links below to see what
     cool stuff ev3dev can do!
 </p>

--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,7 @@
 User-agent: *
-Allow:
+Disallow: /issues/
+Disallow: /fonts/
+Disallow: /images/
+Disallow: /javascripts/
+Disallow: /stylesheets/
+Disallow: /contributing/

--- a/share.md
+++ b/share.md
@@ -1,5 +1,6 @@
 ---
 title: Share
+excerpt: "Do you like ev3dev? Show your support! We invite you to star the repo on GitHub and submit your cool projects to our projects page."
 ---
 <div class="lead">
     <center>

--- a/share.md
+++ b/share.md
@@ -1,6 +1,6 @@
 ---
 title: Share
-excerpt: "Do you like ev3dev? Show your support! We invite you to star the repo on GitHub and submit your cool projects to our projects page."
+excerpt: "We have a projects page where users can browse projects that have been built using ev3dev. You can add your own too! Each project gets a dedicated page for the author to explain what they have been working on, as well as provide videos, pictures, build instructions, code, and any other media that pertains to the project."
 ---
 <div class="lead">
     <center>

--- a/support.md
+++ b/support.md
@@ -1,6 +1,7 @@
 ---
 title: "Get Help"
 redirect_from: /issues/index.html
+excerpt: "Have a problem or question? We are here to help - but you have to help us help you. We keep track of problems, suggestions and questions about ev3dev using GitHub Issues. This lets us keep everything in one place."
 ---
 
 * Table of Contents


### PR DESCRIPTION
This adds logic to the head template that generates a description `meta` tag with content from the page's `excerpt`. That field is automatically populated on posts, and you can manually override or add it on any page you want. The description content is often what search engines display on results pages, so we want to make sure we have good content there.

The majority of the content is copied from the first paragraph on the page, but in some cases I added an extra sentence or modified wording to make it make sense in search results. On some of these, I was having some trouble coming up with good descriptions -- if there are any suggestions for content, I'd be happy to make changes.

I focused on the primary landing pages and the major posts and documentation items, but didn't add excerpts for everything. It would also be great if the script that generates docs pages would add excerpts.
