### PR TITLE
Update NXT Temperature Sensor entry

### DIFF
--- a/_includes/sensor-connection.html
+++ b/_includes/sensor-connection.html
@@ -30,9 +30,6 @@
 {% when 'gpio-pcf857xr' or 'pcf8591' or 'rtc-ds1307' %}
     {% assign connection = "I2C/Other" %}
     {% assign autodetect = "N[^standard-i2c]" %}
-{% when 'lm75' %}
-    {% assign connection = "I2C/Other" %}
-    {% assign autodetect = "Y[^lm75]" %}
 {% when 'ev3-uart-sensor' %}
     {% assign connection = "UART/EV3" %}
     {% assign autodetect = "Y" %}

--- a/docs/sensors/index.md
+++ b/docs/sensors/index.md
@@ -197,11 +197,6 @@ kernel.
     exact type of sensor cannot be determined. See [Using I2C Sensors]
     for information on how to manually load the correct driver.
 
-[^lm75]: <s>Temperature sensors using the lm75 module can be auto-detected.
-    You must run `modprobe lm75` for this to happen. You can also make the
-    lm75 module load automatically on boot by adding it to `/etc/modules`.</s>
-    Automatic detection not working. See <https://github.com/ev3dev/ev3dev/issues/622>.
-
 [^ev3-analog-driver]: The `XX` in `ev3-analog-XX` is replaced with the type id
     of the sensor (`01` to `14`). Type id `02` is the LEGO EV3 Touch sensor,
     so `ev3-analog-02` does not exist.


### PR DESCRIPTION
Waiting on ev3dev/lego-linux-drivers#32.