### PR TITLE
Update ev3go URL for package refactoring

### DIFF
--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -48,7 +48,7 @@ libraries may be outdated due to the fast development cycle of ev3dev.
 
 * Extra languages:
     * [Go](https://github.com/ldmberman/GoEV3) updated for ev3dev-jessie by @ldmberman, [original](https://github.com/mattrajca/GoEV3) by @mattrajca
-    * [Go](https://github.com/ev3go/ev3) closely following the ev3dev API specification by the @ev3go project.
+    * [Go](https://github.com/ev3go/ev3dev) closely following the ev3dev API specification by the @ev3go project.
     * [Python](https://github.com/topikachu/python-ev3) by @topikachu
     * [C (with optional Perl, Python and Ruby bindings)](https://github.com/in4lio/ev3dev-c) by @in4lio
     * [C](https://github.com/theZiz/ev3c) by @theZiz


### PR DESCRIPTION
ev3go just underwent some restructuring to make handling non-LEGO devices easier to cope with. This reflects that change.

@dlech Please take a look.