### PR TITLE
Add .nojekyll file when publishing using publish script

### DIFF
--- a/publish.rb
+++ b/publish.rb
@@ -52,6 +52,9 @@ Dir.mktmpdir do |tmp|
 
     # having cname sends you annoying email
     FileUtils.rm 'CNAME'
+    
+    # adding a .nojekyll file disables unnecessary build job on GH Pages
+    FileUtils.touch '.nojekyll'
 
     system "git add ."
 


### PR DESCRIPTION
Fixes #162.

I haven't published to confirm that this works end-to-end (because my Pages branch is currently preoccupied with another PR), but I know that this is successfully creating the right file and staging/committing it. Separately, I also timed the delay between push and web update on a different site that has a `.nojekyll` and it was less than 10 seconds. So overall, I expect that this will be an improvement.