### PR TITLE
Bring library info up-to-date in getting started and on libraries page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -231,7 +231,7 @@ to connect for the first time. You can setup additional connections using the
 
 ## Step 6: Do something awesome
 
-The brick can run almost all languages that any other Linux distro can, so your
+The brick can run almost all programming languages that any other Linux distro can, so your
 favorite language is probably supported. Language bindings have already been
 written for many languages. **You can learn more about the available libraries
 [here](/docs/libraries).**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -231,31 +231,14 @@ to connect for the first time. You can setup additional connections using the
 
 ## Step 6: Do something awesome
 
-This will be where we tell you how to use the EV3's main functions, and how
-to write programs. We are still learning, so everything here should be
-considered experimental and subject to major changes.
-
-### Using the EV3 hardware drivers
-
-Here are some guides for using each of the major components.
-
-* [Sensors](/docs/sensors)
-* [Motors](/docs/tutorials/tacho-motors/)
-* [Sound](https://github.com/ev3dev/ev3dev/wiki/Using-Sound)
-* [LCD](/docs/tutorials/using-ev3-lcd/)
-* [Buttons](/docs/tutorials/using-ev3-buttons/)
-* [LEDs](https://github.com/ev3dev/ev3dev/wiki/Using-the-LEDs)
-* [Bluetooth](https://github.com/ev3dev/ev3dev/wiki/Using-Bluetooth)
-
-### Writing programs
-
-There are a number of programming languages available to use. The brick can
-run almost all languages that any other Linux distro can, so your favorite
-language is probably supported. Language bindings have already been written
-for many languages. You can learn more about the available libraries [here](/docs/libraries).
+The brick can run almost all languages that any other Linux distro can, so your
+favorite language is probably supported. Language bindings have already been
+written for many languages. **You can learn more about the available libraries
+[here](/docs/libraries).**
 
 If the language you want isn't listed, you still can use it, but you'll have to
-do more of the heavy lifting yourself using the guides above. Once you get the
+do more of the heavy lifting yourself. You can look at the [driver index page](/docs/drivers/)
+for information on the interfaces you need to use to control devices. Once you get the
 hang of it, you can even write your own interface library and have it listed here!
 
 </div>

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -20,7 +20,7 @@ supports multiple implementations of the ev3dev API in a variety of languages.
     * [C++](https://github.com/ddemidov/ev3dev-lang-cpp)
     * [Node.js](https://github.com/wasabifan/ev3dev-lang-js)
     * [Python](https://github.com/rhempel/ev3dev-lang-python)
-    * [@mob41's ev3dev-lang-java](https://github.com/mob41/ev3dev-lang-java)
+    * [Java](https://github.com/mob41/ev3dev-lang-java)
 
 ## Programming toolkit for ev3dev
 

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -20,9 +20,7 @@ supports multiple implementations of the ev3dev API in a variety of languages.
     * [C++](https://github.com/ddemidov/ev3dev-lang-cpp)
     * [Node.js](https://github.com/wasabifan/ev3dev-lang-js)
     * [Python](https://github.com/rhempel/ev3dev-lang-python)
-    * Java
-      * [@mob41's ev3dev-lang-java](https://github.com/mob41/ev3dev-lang-java), which follows closely to the format of the other libraries.
-      * [@jabrena's ev3dev-lang-java](https://github.com/ev3dev-lang-java/ev3dev-lang-java), an interface more similar to that of LeJOS.
+    * [@mob41's ev3dev-lang-java](https://github.com/mob41/ev3dev-lang-java)
 
 ## Programming toolkit for ev3dev
 
@@ -47,6 +45,7 @@ libraries may be outdated due to the fast development pace of ev3dev.
 * Extra languages:
     * [Go](https://github.com/ldmberman/GoEV3) updated for ev3dev-jessie by @ldmberman, [original](https://github.com/mattrajca/GoEV3) by @mattrajca
     * [Go](https://github.com/ev3go/ev3dev) closely following the ev3dev API specification by the @ev3go project.
+    * [Java](https://github.com/ev3dev-lang-java/ev3dev-lang-java) an interface similar to that of LeJOS by @jabrena
     * [Python](https://github.com/topikachu/python-ev3) by @topikachu
     * [C (with optional Perl, Python and Ruby bindings)](https://github.com/in4lio/ev3dev-c) by @in4lio
     * [C](https://github.com/theZiz/ev3c) by @theZiz

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -14,16 +14,15 @@ We have a repository of officially maintained language bindings, as well as many
 ## Unified Libraries
 
 Our official "unified" [language binding repository](http://github.com/ev3dev/ev3dev-lang)
-currently has support for C++, Lua, Node.js, and Python.
-These libraries are all built around a single
-[API specification](http://ev3dev-lang.readthedocs.org/en/latest/spec.html)
-that ensures that interface is almost identical for each, and they are being updated and
-enhanced regularly.
+supports multiple implementations of the ev3dev API in a variety of languages.
 
 * Unified bindings:
     * [C++](https://github.com/ddemidov/ev3dev-lang-cpp)
     * [Node.js](https://github.com/wasabifan/ev3dev-lang-js)
     * [Python](https://github.com/rhempel/ev3dev-lang-python)
+    * Java
+      * [@mob41's ev3dev-lang-java](https://github.com/mob41/ev3dev-lang-java), which follows closely to the format of the other libraries.
+      * [@jabrena's ev3dev-lang-java](https://github.com/ev3dev-lang-java/ev3dev-lang-java), an interface more similar to that of LeJOS.
 
 ## Programming toolkit for ev3dev
 
@@ -40,11 +39,10 @@ for ev3dev is written using this library.
 [GObjectIntrospection]: https://wiki.gnome.org/Projects/GObjectIntrospection
 [brickman]: https://github.com/ev3dev/brickman
 
-
 ## Extra languages
 We also have many great contrubutors that are maintaining extra libraries for
 languages not included in our other repository.  Note that some of these
-libraries may be outdated due to the fast development cycle of ev3dev.
+libraries may be outdated due to the fast development pace of ev3dev.
 
 * Extra languages:
     * [Go](https://github.com/ldmberman/GoEV3) updated for ev3dev-jessie by @ldmberman, [original](https://github.com/mattrajca/GoEV3) by @mattrajca


### PR DESCRIPTION
Fixes #175. It turns out that there were no links anywhere on the site to the `/docs/drivers` page, so this should also make that more discoverable.