### PR TITLE
Add universal API cache and implement proper fallbacks

### DIFF
--- a/_includes/author-card.html
+++ b/_includes/author-card.html
@@ -10,7 +10,7 @@
 <!-- this looks weird, but it was the only way I could figure out how to test
      that the first character of include.author is "@" -->
 {% if at_sign.size > 0 and test_at_sign_is_first == 3 %}
-    <div data-card-user="{{author_no_at_sign}}" class="{{ extra_classes }}"></div><br/>
+    <div class="user-card {{ extra_classes }}" data-card-user="{{author_no_at_sign}}"><div class="user-card-name">{{ include.author }}</div></div></br>
 {% else %}
     <div class="user-card {{ extra_classes }}"><div class="user-card-name">{{ include.author }}</div></div>
 {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -35,6 +35,8 @@
     <script src="/javascripts/respond.js"></script>
     <script src="/javascripts/ua-parser.min.js"></script>
 
+    <!-- Caches data from requests to API endpoints -->
+    <script src="/javascripts/api-cache.js"></script>
     <!-- Loads user-cards from GH API -->
     <script src="/javascripts/cards.js"></script>
     <!-- Configures special anchors to link to the most recent ev3dev release -->

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,6 +50,8 @@ please [open an issue on GitHub](/support){: .alert-link}.
 
 ## Step 1: Download the latest ev3dev image file
 
+<div class="release-link-container" markdown="1">
+
 <br/>
 <div class="text-center">
 <a data-release-link-platform="ev3" class="btn btn-lg btn-primary"><span class="glyphicon glyphicon-download-alt"></span> Download for LEGO MINDSTORMS EV3</a>
@@ -65,6 +67,17 @@ To get started, you will need to download the release corresponding to the platf
 you are using. If you are looking for older releases or other file types, you can
 check out the [GitHub releases page][releases].
 
+</div>
+<div class="release-link-alt" markdown="1">
+To get started, you will need to download the release corresponding to the platform
+you are using. Visit the [GitHub releases page][releases] and find the image that
+corresponds to your platform:
+
+- Releases for the LEGO MINDSTORMS EV3 start with `ev3- `
+- Releases for the Raspberry Pi 1 start with `rpi-`
+- Releases for the Raspberry Pi 2 and 3 start with `rpi2-`
+- Releases for the BeagleBone start with `evb-`
+</div>
 </div>
 </div>
 

--- a/javascripts/api-cache.js
+++ b/javascripts/api-cache.js
@@ -1,0 +1,50 @@
+var cacheKey = "api-cache";
+
+function supportsHtml5Storage() {
+    try {
+        return 'localStorage' in window && window['localStorage'] !== null;
+    } catch (e) {
+        return false;
+    }
+}
+
+function getApiValue(endpointUrl, cacheTime, callback) {
+    try {
+        var cacheData = supportsHtml5Storage() ? JSON.parse(localStorage[cacheKey]) : null;
+        // This does an exact match for the URL given. Different spacing, duplicate slashes,
+        // alternate caps, etc. will result in the cache being bypassed.
+        if (cacheData && cacheData[endpointUrl] && Date.now() - cacheData[endpointUrl].dateRetrieved < cacheTime) {
+            callback(cacheData[endpointUrl].requestResult);
+            return;
+        }
+    }
+    catch (e) {
+        // Ignore the error; if the saved JSON is invalid, we'll just request it from the server.
+    }
+    
+    console.log('No cached copy of API data for endpoint "' + endpointUrl  + '" found. Downloading from remote server.');
+    $.ajax(endpointUrl).done(function (apiData) {
+        if (supportsHtml5Storage()) {
+            var cacheData = {};
+            
+            try {
+                cacheData = JSON.parse(localStorage[cacheKey]);
+            }
+            catch(e) {
+                // Ignore error; either the cache doesn't exist or it is invalid
+            }
+            
+            cacheData[endpointUrl] = {
+                dateRetrieved: Date.now(),
+                requestResult: apiData
+            };
+            
+            localStorage.setItem(cacheKey, JSON.stringify(cacheData));
+        }
+        
+        callback(apiData);
+    }).fail(function (xhr, error) {
+        console.error("Error getting API data: " + error);
+        callback(null, error);
+    });
+}

--- a/javascripts/cards.js
+++ b/javascripts/cards.js
@@ -5,31 +5,29 @@ $(document).ready(function () {
     $('div[data-card-user]').each(function (i, element) {
         var $cardDiv = $(element);
         getApiValue('https://api.github.com/users/' + $cardDiv.data('card-user'), userCardCacheTimeMillis, function (userData, error) {
-            $cardDiv.addClass('user-card');
-
-            if (error) {
-                console.error("User cards not available! Using static text card instead.");
-                $cardDiv.append('<div class="user-card-name">@' + $cardDiv.data('card-user')  + '</div>');
+            if (error || !userData) {
+                console.error("User card data not available! Using static text card instead.");
+                return;
             }
-            else {
-                $cardDiv = $('<a href="' + userData.html_url + '"></a>').appendTo($cardDiv);
-                
-                var $avatarDiv = $('<div class="user-card-avatar"><img src="' + userData.avatar_url + '"/></div>').appendTo($cardDiv);
-                var $textDiv = $('<div class="user-card-text"></div>').appendTo($cardDiv);
+            
+            $cardDiv.empty();
+            $cardDiv = $('<a href="' + userData.html_url + '"></a>').appendTo($cardDiv);
+            
+            var $avatarDiv = $('<div class="user-card-avatar"><img src="' + userData.avatar_url + '"/></div>').appendTo($cardDiv);
+            var $textDiv = $('<div class="user-card-text"></div>').appendTo($cardDiv);
 
-                $textDiv.append('<div class="user-card-name">' + (userData.name || userData.login) + '</div>');
-                $textDiv.append('<div class="user-card-login">@' + userData.login + '</div>');
+            $textDiv.append('<div class="user-card-name">' + (userData.name || userData.login) + '</div>');
+            $textDiv.append('<div class="user-card-login">@' + userData.login + '</div>');
 
-                // Give the text a margin to make sure it does not overlap the avatar
-                $avatarDiv.resize(function () {
-                    $textDiv.css({
-                        width: 'auto',
-                        "margin-left": $avatarDiv.height()
-                    });
+            // Give the text a margin to make sure it does not overlap the avatar
+            $avatarDiv.resize(function () {
+                $textDiv.css({
+                    width: 'auto',
+                    "margin-left": $avatarDiv.height()
                 });
+            });
 
-                $avatarDiv.resize();
-            }
+            $avatarDiv.resize();
         });
     });
 });

--- a/javascripts/cards.js
+++ b/javascripts/cards.js
@@ -1,28 +1,35 @@
+// Cache will time out after 1 hour
+var userCardCacheTimeMillis = 60 * 60 * 1000;
+
 $(document).ready(function () {
     $('div[data-card-user]').each(function (i, element) {
         var $cardDiv = $(element);
-        $.ajax('https://api.github.com/users/' + $cardDiv.data('card-user')).done(function (userData) {
+        getApiValue('https://api.github.com/users/' + $cardDiv.data('card-user'), userCardCacheTimeMillis, function (userData, error) {
             $cardDiv.addClass('user-card');
-            $cardDiv.append('<a href="' + userData.html_url + '"></a>');
-            $cardDiv = $cardDiv.children(':last-child')
 
-            $cardDiv.append('<div class="user-card-avatar"><img src="' + userData.avatar_url + '"/></div>');
-            var $avatarDiv = $cardDiv.children(':last-child');
-            $cardDiv.append('<div class="user-card-text"></div>');
-            var $textDiv = $cardDiv.children(':last-child');
-            
-            $textDiv.append('<div class="user-card-name">' + (userData.name || userData.login) + '</div>');
-            $textDiv.append('<div class="user-card-login">@' + userData.login + '</div>');
-            
-            // Give the text a margin to make sure it does not overlap the avatar
-            $avatarDiv.resize(function() {
-                $textDiv.css({
-                    width: 'auto',
-                    "margin-left": $avatarDiv.height()
+            if (error) {
+                console.error("User cards not available! Using static text card instead.");
+                $cardDiv.append('<div class="user-card-name">@' + $cardDiv.data('card-user')  + '</div>');
+            }
+            else {
+                $cardDiv = $('<a href="' + userData.html_url + '"></a>').appendTo($cardDiv);
+                
+                var $avatarDiv = $('<div class="user-card-avatar"><img src="' + userData.avatar_url + '"/></div>').appendTo($cardDiv);
+                var $textDiv = $('<div class="user-card-text"></div>').appendTo($cardDiv);
+
+                $textDiv.append('<div class="user-card-name">' + (userData.name || userData.login) + '</div>');
+                $textDiv.append('<div class="user-card-login">@' + userData.login + '</div>');
+
+                // Give the text a margin to make sure it does not overlap the avatar
+                $avatarDiv.resize(function () {
+                    $textDiv.css({
+                        width: 'auto',
+                        "margin-left": $avatarDiv.height()
+                    });
                 });
-            });
-            
-            $avatarDiv.resize();
-        });        
+
+                $avatarDiv.resize();
+            }
+        });
     });
 });

--- a/javascripts/releases.js
+++ b/javascripts/releases.js
@@ -1,4 +1,3 @@
-var ev3devRepoReleaseCacheKey = 'ev3dev-repo-release-cache';
 // Cache will time out after 20 minutes
 var releaseCacheTimeMillis = 20 * 60 * 1000;
 
@@ -9,71 +8,50 @@ var releasePlatformRegexes = {
     evb: "evb-[\\w\\d-]*\\.img\\.xz",
 }
 
-function supportsHtml5Storage() {
-    try {
-        return 'localStorage' in window && window['localStorage'] !== null;
-    } catch (e) {
-        return false;
-    }
+function initDownloadLinks() {
+    getApiValue('https://api.github.com/repos/ev3dev/ev3dev/releases', releaseCacheTimeMillis, function (releases, error) {
+        if(error) {
+            console.error("Download links not available! Falling back to static content.");
+            $('.release-link-container').hide();
+            $('.release-link-alt').show();
+            
+            return;
+        }
+        
+        releases.sort(function (a, b) {
+            if (Date.parse(a['created_at']) < Date.parse(b['created_at']))
+                return 1;
+            if (Date.parse(a['created_at']) > Date.parse(b['created_at']))
+                return -1;
+
+            return 0;
+        });
+
+        $('a[data-release-link-platform]').each(function (i, element) {
+            var $linkElem = $(element);
+            var targetReleasePlatform = $linkElem.data('release-link-platform');
+            if (!releasePlatformRegexes[targetReleasePlatform]) {
+                console.error('"' + targetReleasePlatform + '" is an invalid release target.');
+                return true;
+            }
+
+            var platformRegex = new RegExp(releasePlatformRegexes[targetReleasePlatform]);
+
+            for (var releaseIndex in releases) {
+                var releaseAssets = releases[releaseIndex].assets;
+                for (var assetIndex in releaseAssets) {
+                    if (platformRegex.test(releaseAssets[assetIndex].name)) {
+                        $linkElem.attr('href', releaseAssets[assetIndex]['browser_download_url']);
+                        return true;
+                    }
+                }
+            }
+        });
+    });
 }
 
 $(document).ready(function () {
     if ($('a[data-release-link-platform]').length > 0) {
-        function initReleaseLinks(releases) {
-            releases.sort(function (a, b) {
-                if (Date.parse(a['created_at']) < Date.parse(b['created_at']))
-                    return 1;
-                if (Date.parse(a['created_at']) > Date.parse(b['created_at']))
-                    return -1;
-
-                return 0;
-            });
-
-            $('a[data-release-link-platform]').each(function (i, element) {
-                var $linkElem = $(element);
-                var targetReleasePlatform = $linkElem.data('release-link-platform');
-                if(!releasePlatformRegexes[targetReleasePlatform]) {
-                    console.error('"' + targetReleasePlatform + '" is an invalid release target.');
-                    return true;
-                }
-                
-                var platformRegex = new RegExp(releasePlatformRegexes[targetReleasePlatform]);
-
-                for(var releaseIndex in releases) {
-                    var releaseAssets = releases[releaseIndex].assets;
-                    for(var assetIndex in releaseAssets) {
-                        if(platformRegex.test(releaseAssets[assetIndex].name)) {
-                            $linkElem.attr('href', releaseAssets[assetIndex]['browser_download_url']);
-                            return true;
-                        }
-                    }
-                }
-            });
-        }
-
-        var cacheData;
-        try {
-            cacheData = supportsHtml5Storage() ? JSON.parse(localStorage.getItem(ev3devRepoReleaseCacheKey)) : null;
-        }
-        catch(e) {
-            // Ignore the error; if the saved JSON is invalid, we'll just request it from the server.
-        }
-        
-        if (cacheData && Date.now() - cacheData.dateRetrieved < releaseCacheTimeMillis) {
-            initReleaseLinks(cacheData.releaseData);
-        }
-        else {
-            console.log("No cached copy of releases found. Downloading from GitHub.");
-            $.ajax('https://api.github.com/repos/ev3dev/ev3dev/releases').done(function (releases) {
-                if (supportsHtml5Storage())
-                    localStorage.setItem(ev3devRepoReleaseCacheKey, JSON.stringify({
-                        dateRetrieved: Date.now(),
-                        releaseData: releases
-                    }));
-                initReleaseLinks(releases);
-            }).fail(function (error) {
-                console.error("Error getting release info: " + error);
-            });
-        }
+        initDownloadLinks();
     }
 });

--- a/javascripts/releases.js
+++ b/javascripts/releases.js
@@ -51,6 +51,11 @@ function initDownloadLinks() {
 }
 
 $(document).ready(function () {
+    // If JS is disabled, this code will never run and the alt content will be left as-is.
+    // We do this as soon as the document loads so that the page flash is minimal.
+    $('.release-link-alt').hide();
+    $('.release-link-container').show();
+    
     if ($('a[data-release-link-platform]').length > 0) {
         initDownloadLinks();
     }

--- a/stylesheets/page-content.scss
+++ b/stylesheets/page-content.scss
@@ -37,3 +37,7 @@
 .colored-section {
     padding-bottom: 10.5px;
 }
+
+.release-link-alt {
+    display: none;
+}

--- a/stylesheets/page-content.scss
+++ b/stylesheets/page-content.scss
@@ -38,6 +38,6 @@
     padding-bottom: 10.5px;
 }
 
-.release-link-alt {
+.release-link-container {
     display: none;
 }


### PR DESCRIPTION
This is a follow-up to #170.

This does three major things:
- Makes the API caching logic available generically instead of only for releases and uses that cache in user cards
- Adds fallback logic so that both cards and the downloads area will work if GitHub is unavailable
- Modifies card and download link logic so that they will be functional if JavaScript is disabled or broken (e.g. JQuery failed to load)

One thing I'd like to point out explicitly is [an addition to the getting started guide](https://github.com/ev3dev/ev3dev.github.io/compare/master...WasabiFan:add-universal-api-cache?expand=1#diff-a39c9f7aa728d5fa3b973bc6ba49228aR71). This content is shown by default and works as a fallback if the intelligent download buttons don't load properly (for the reasons mentioned earlier, among others). The first thing that happens when the document loads is that -- assuming JavaScipt and JQuery are both functional -- the deficient buttons are shown  and the fallback content is hidden. I say "deficient" because they don't actually have any `href` set on them by default. This means that the initial flash is minimal for users when everything is working properly. If, after attempting to load the buttons, it turns out that GitHub can't be reached, it hides the buttons and switches back to the fallback content.

I have made similar changes to the card logic so that cards will include fallback text in the static HTML until the JavaScript initializes them.

While I had originally disregarded the possibility of these issues, I realized that a large part of this site's audience is the type of person that might disable JavaScript to protect privacy. I figure this should fix any potential issues.