### PR TITLE
Make release auto-detect logic accept bone-* images

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,7 +59,7 @@ please [open an issue on GitHub](/support){: .alert-link}.
 <h2 class="centered-light-heading"> Other platforms </h2>
 <a data-release-link-platform="rpi" class="btn btn-md btn-primary download-button-small">Raspberry Pi 1</a>
 <a data-release-link-platform="rpi2" class="btn btn-md btn-primary download-button-small">Raspberry Pi 2</a>
-<a data-release-link-platform="evb" class="btn btn-md btn-primary download-button-small">BeagleBone</a>
+<a data-release-link-platform="bone" class="btn btn-md btn-primary download-button-small">BeagleBone</a>
 </div>
 
 <br/>

--- a/javascripts/releases.js
+++ b/javascripts/releases.js
@@ -5,7 +5,7 @@ var releasePlatformRegexes = {
     ev3: "ev3-[\\w\\d-]*\\.img\\.xz",
     rpi: "rpi-[\\w\\d-]*\\.img\\.xz",
     rpi2: "rpi2-[\\w\\d-]*\\.img\\.xz",
-    evb: "evb-[\\w\\d-]*\\.img\\.xz",
+    bone: "(evb|bone)-[\\w\\d-]*\\.img\\.xz",
 }
 
 function initDownloadLinks() {


### PR DESCRIPTION
This change should make the transition to image names that start with `bone-*` seamless; whenever the next round of images is released, the download buttons should be already prepared to serve the BeagleBone ones with the new name. We will still need to manually update the alternate text which appears when GitHub can't be reached.