### PR TITLE
Accommodate taller images in screenshots

### DIFF
--- a/stylesheets/site-structure.scss
+++ b/stylesheets/site-structure.scss
@@ -90,7 +90,7 @@ h1.panel-title {
 }
 
 .screenshot > a > img {
-    max-height: 480px;
+    max-height: 640px;
 }
 
 .inline-screenshot {


### PR DESCRIPTION
Images of a taller aspect ratio were prevented from being full-width because of this rule, so this loosens it up a bit.