### PR TITLE
Rewrite and restructure libraries page

### DIFF
--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -4,32 +4,42 @@ subtitle: Control ev3dev devices from code
 excerpt: "If you are looking to write a program that takes advantage of motors, sensors, or other native devices, using a language binding is the way to go. These are the best options for each language."
 ---
 
-Before you can start writing code that runs on ev3dev, you need to choose a programming language. Community members have built libraries that let you use features
-such as motors and sensors from your code. Choose the language you want from below and follow the link to the library's homepage get started.
+Before you can start writing code that runs on ev3dev, you need to choose a
+programming language. Community members have built libraries that let you use
+featuressuch as motors and sensors from your code. Choose the language you want
+from below and follow the link to the library's homepage get started.
 
 ## Python
 <https://github.com/rhempel/ev3dev-lang-python>
 
-Python is a high-level, general-purpose, interpreted scripting language. It is great for beginners, while also powerful for experienced coders.
-If you are new to programming and unsure which language to choose, Python is a great choice!
+Python is a high-level, general-purpose, interpreted scripting language. It is
+great for beginners, while also powerful for experienced coders.If you are new
+to programming and unsure which language to choose, Python is a great choice!
 
-**Warning!** There is another Python library named `python-ev3` created by @topikachu which is _not_ the same as this one. When searching for documentation online, make sure that you are reading about @rhempel's `ev3dev-lang-python`.
+**Warning!** There is another Python library named `python-ev3` created by
+@topikachu which is _not_ the same as this one. When searching for documentation
+online, make sure that you are reading about @rhempel's `ev3dev-lang-python`.
 
 [Get started with Python](https://github.com/rhempel/ev3dev-lang-python){: .btn .btn-default }
 
 ## JavaScript
 <https://github.com/wasabifan/ev3dev-lang-js>
 
-JavaScript is the scripting language of the Web. With a program called Node.js, you can write JavaScript that can be run locally like any other scripting language.
-JavaScript with Node.js is great for writing web servers and other asynchronous programs which don't need to run tight loops or precise timers. It has a syntax similar to that of C and related
-languages, and is relatively easy to learn.
+JavaScript is the scripting language of the Web. With a program called Node.js,
+you can write JavaScript that can be run locally like any other scripting
+language. JavaScript with Node.js is great for writing web servers and other
+asynchronous programs which don't need to run tight loops or precise timers. It
+has a syntax similar to that of C and related languages, and is relatively easy
+to learn.
 
 [Get started with JavaScript](https://github.com/wasabifan/ev3dev-lang-js){: .btn .btn-default }
 
 ## Go
 <https://github.com/ev3go/ev3dev>
 
-Go is a compiled, statically-typed language created at Google. It aims to be simple and light while still providing modern language features. While it is a compiled language, cross-compilation is _not_ required to run code on ev3dev,
+Go is a compiled, statically-typed language created at Google. It aims to be
+simple and light while still providing modern language features. While it is a
+compiled language, cross-compilation is _not_ required to run code on ev3dev,
 unlike other compiled languages; this makes Go much simpler to work with.
 
 [Get started with Go](https://github.com/ev3go/ev3dev){: .btn .btn-default }
@@ -37,15 +47,17 @@ unlike other compiled languages; this makes Go much simpler to work with.
 ## C++
 <https://github.com/ddemidov/ev3dev-lang-cpp>
 
-C++ is a low-level, compiled language which is highly performant while still providing modern language features. It is best for applications which require the fastest execution or
-interaction with existing C++ libraries.
+C++ is a low-level, compiled language which is highly performant while still
+providing modern language features. It is best for applications which require
+the fastest execution or interaction with existing C++ libraries.
 
 [Get started with C++](https://github.com/ddemidov/ev3dev-lang-cpp){: .btn .btn-default }
 
 ## C
 <https://github.com/in4lio/ev3dev-c>
 
-C is a low-level, compiled language which is useful for interacting with other C-based code. It is very lightweight and often the most portable across platforms.
+C is a low-level, compiled language which is useful for interacting with other
+C-based code. It is very lightweight and often the most portable across platforms.
 
 [Get started with C](https://github.com/in4lio/ev3dev-c){: .btn .btn-default }
 
@@ -53,9 +65,13 @@ C is a low-level, compiled language which is useful for interacting with other C
 ## Vala, Genie and other GObject-based languages with ev3devKit
 <https://github.com/ev3dev/ev3devKit>
 
-Through [GObject-introspection](https://wiki.gnome.org/Projects/GObjectIntrospection), this library can be used by languages including Vala and Genie, among [many others](https://wiki.gnome.org/Projects/GObjectIntrospection/Users).
-This is great for people who want to use higher-level syntax while still producing a performant application, or people who want a less error-prone API for C. The [Brick Manager][https://github.com/ev3dev/brickman]
-for ev3dev is written using this library.
+Through [GObject-introspection](https://wiki.gnome.org/Projects/GObjectIntrospection),
+this library can be used by languages including Vala and Genie, among
+[many others](https://wiki.gnome.org/Projects/GObjectIntrospection/Users). This
+is great for people who want to use higher-level syntax while still producing a
+performant application, or people who want a less error-prone API for C. The
+[Brick Manager][https://github.com/ev3dev/brickman] for ev3dev is written using
+this library.
 
 [Get started with ev3devKit](https://github.com/ev3dev/ev3devKit){: .btn .btn-default }
 
@@ -64,28 +80,35 @@ for ev3dev is written using this library.
 
 # Alternative implementations and wrappers
 
-Some of the libraries above also implement interfaces for other languages. If you're looking for an alternative implementation for any reason, try out the options below.
+Some of the libraries above also implement interfaces for other languages. If
+you're looking for an alternative implementation for any reason, try out the
+options below.
 
 ## Python, Ruby and Perl with ev3dev-c
 <https://github.com/in4lio/ev3dev-c>
 
-ev3dev-c also has wrappers for [Python](https://github.com/in4lio/ev3dev-c/tree/master/python), [Ruby](https://github.com/in4lio/ev3dev-c/tree/master/ruby) and [Perl](https://github.com/in4lio/ev3dev-c/tree/master/perl). 
+ev3dev-c also has wrappers for [Python](https://github.com/in4lio/ev3dev-c/tree/master/python),
+[Ruby](https://github.com/in4lio/ev3dev-c/tree/master/ruby) and [Perl](https://github.com/in4lio/ev3dev-c/tree/master/perl). 
 
 ## Python with ev3devKit
 <https://github.com/ev3dev/ev3devKit>
 
-Ev3devKit also has a Python wrapper. You can find demos of using ev3devKit from Python [here](https://github.com/ev3dev/ev3devKit/tree/ev3dev-jessie/demo/python).
+Ev3devKit also has a Python wrapper. You can find demos of using ev3devKit from
+Python [here](https://github.com/ev3dev/ev3devKit/tree/ev3dev-jessie/demo/python).
 
 # Out-of-date, abandoned and unfinished implementations
 
 <div class="panel panel-danger">
 <div class="panel-heading">
     {% include icon.html type="danger" %}
-    Listings below this point are for libraries that are not up-to-date, have been abandoned, or are unfinished.
+    Listings below this point are for libraries that are not up-to-date, have
+    been abandoned, or are unfinished.
 </div>
 <div class="panel-body">
 <p>
-    Use them with caution, as some functionality will likely be broken. If you see a library below that you'd like to see in a better state, consider contributing to it to get it updated and ready to use.
+    Use them with caution, as some functionality will likely be broken. If you
+    see a library below that you'd like to see in a better state, consider
+    contributing to it to get it updated and ready to use.
 </p>
 </div>
 </div>

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -1,5 +1,5 @@
 ---
-title: Interface libraries
+title: Libraries
 subtitle: Control ev3dev devices from code
 excerpt: "If you are looking to write a program that takes advantage of motors, sensors, or other native devices, using a language binding is the way to go. These are the best options for each language."
 ---
@@ -13,7 +13,7 @@ such as motors and sensors from your code. Choose the language you want from bel
 Python is a high-level, general-purpose, interpreted scripting language. It is great for beginners, while also powerful for experienced coders.
 If you are new to programming and unsure which language to choose, Python is a great choice!
 
-**Warning!** There is another Python library created by @topikachu which is _not_ the same as this one. When searching for documentation online, make sure that you are reading about @rhempel's `ev3dev-lang-python`.
+**Warning!** There is another Python library named `python-ev3` created by @topikachu which is _not_ the same as this one. When searching for documentation online, make sure that you are reading about @rhempel's `ev3dev-lang-python`.
 
 [Get started with Python](https://github.com/rhempel/ev3dev-lang-python){: .btn .btn-default }
 
@@ -29,7 +29,8 @@ languages, and is relatively easy to learn.
 ## Go
 <https://github.com/ev3go/ev3dev>
 
-Go is a compiled, statically-typed language created by at Google. It aims to be simple and light while still providing modern language features.
+Go is a compiled, statically-typed language created at Google. It aims to be simple and light while still providing modern language features. While it is a compiled language, cross-compilation is _not_ required to run code on ev3dev,
+unlike other compiled languages; this makes Go much simpler to work with.
 
 [Get started with Go](https://github.com/ev3go/ev3dev){: .btn .btn-default }
 
@@ -58,17 +59,54 @@ for ev3dev is written using this library.
 
 [Get started with ev3devKit](https://github.com/ev3dev/ev3devKit){: .btn .btn-default }
 
---------
+<br>
+<br>
 
-{% include icon.html type="danger" %}
-Listings below this point are for libraries that are either not up-to-date or have been abandoned. Use them with caution, as functionality will likely be broken.
-{: .alert .alert-danger}
+# Alternative implementations and wrappers
+
+Some of the libraries above also implement interfaces for other languages. If you're looking for an alternative implementation for any reason, try out the options below.
+
+## Python, Ruby and Perl with ev3dev-c
+<https://github.com/in4lio/ev3dev-c>
+
+ev3dev-c also has wrappers for [Python](https://github.com/in4lio/ev3dev-c/tree/master/python), [Ruby](https://github.com/in4lio/ev3dev-c/tree/master/ruby) and [Perl](https://github.com/in4lio/ev3dev-c/tree/master/perl). 
+
+## Python with ev3devKit
+<https://github.com/ev3dev/ev3devKit>
+
+Ev3devKit also has a Python wrapper. You can find demos of using ev3devKit from Python [here](https://github.com/ev3dev/ev3devKit/tree/ev3dev-jessie/demo/python).
+
+# Out-of-date, abandoned and unfinished implementations
+
+<div class="panel panel-danger">
+<div class="panel-heading">
+    {% include icon.html type="danger" %}
+    Listings below this point are for libraries that are not up-to-date, have been abandoned, or are unfinished.
+</div>
+<div class="panel-body">
+<p>
+    Use them with caution, as some functionality will likely be broken. If you see a library below that you'd like to see in a better state, consider contributing to it to get it updated and ready to use.
+</p>
+</div>
+</div>
+
+## C#
+<https://github.com/pgrudzien12/ev3dev-lang-csharp>
 
 ## Pure Java
 <https://github.com/mob41/ev3dev-lang-java>
 
 ## Java LeJOS compatibility layer
 <https://github.com/ev3dev-lang-java/ev3dev-lang-java>
+
+## R
+<https://github.com/ev3dev/ev3dev-lang/tree/R-legacy/R>
+
+## Lua
+<https://github.com/rhempel/ev3dev-lang-lua>
+
+## Ruby
+<https://github.com/noanoa07/ev3dev_ruby>
 
 ## Clojure
 <https://github.com/annapawlicka/clj-ev3dev>

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -39,8 +39,9 @@ to learn.
 
 Go is a compiled, statically-typed language created at Google. It aims to be
 simple and light while still providing modern language features. While it is a
-compiled language, cross-compilation is _not_ required to run code on ev3dev,
-unlike other compiled languages; this makes Go much simpler to work with.
+compiled language, it has its own built-in cross-compiler, which means that you
+don't need to spend time setting up special tooling like you do with most other
+compiled languages.
 
 [Get started with Go](https://github.com/ev3go/ev3dev){: .btn .btn-default }
 
@@ -113,7 +114,7 @@ Python [here](https://github.com/ev3dev/ev3devKit/tree/ev3dev-jessie/demo/python
 </div>
 </div>
 
-## C#
+## C\#
 <https://github.com/pgrudzien12/ev3dev-lang-csharp>
 
 ## Pure Java

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -1,52 +1,83 @@
 ---
-title: Libraries
-subtitle: Pre-made language bindings that make accessing the EV3 device drivers easy
-excerpt: "If you are looking to write a program that takes advantage of the EV3's motors, sensors, or other native devices, using a language binding is the way to go."
+title: Interface libraries
+subtitle: Control ev3dev devices from code
+excerpt: "If you are looking to write a program that takes advantage of motors, sensors, or other native devices, using a language binding is the way to go. These are the best options for each language."
 ---
 
-* Table of Contents
-{:toc}
+Before you can start writing code that runs on ev3dev, you need to choose a programming language. Community members have built libraries that let you use features
+such as motors and sensors from your code. Choose the language you want from below and follow the link to the library's homepage get started.
 
-If you are looking to write a program that takes advantage of the EV3's motors, sensors, or other native devices,
-using a language binding is the way to go.
-We have a repository of officially maintained language bindings, as well as many more that are maintained separately by contributors on GitHub.
+## Python
+<https://github.com/rhempel/ev3dev-lang-python>
 
-## Unified Libraries
+Python is a high-level, general-purpose, interpreted scripting language. It is great for beginners, while also powerful for experienced coders.
+If you are new to programming and unsure which language to choose, Python is a great choice!
 
-Our official "unified" [language binding repository](http://github.com/ev3dev/ev3dev-lang)
-supports multiple implementations of the ev3dev API in a variety of languages.
+**Warning!** There is another Python library created by @topikachu which is _not_ the same as this one. When searching for documentation online, make sure that you are reading about @rhempel's `ev3dev-lang-python`.
 
-* Unified bindings:
-    * [C++](https://github.com/ddemidov/ev3dev-lang-cpp)
-    * [Node.js](https://github.com/wasabifan/ev3dev-lang-js)
-    * [Python](https://github.com/rhempel/ev3dev-lang-python)
-    * [Java](https://github.com/mob41/ev3dev-lang-java)
+[Get started with Python](https://github.com/rhempel/ev3dev-lang-python){: .btn .btn-default }
 
-## Programming toolkit for ev3dev
+## JavaScript
+<https://github.com/wasabifan/ev3dev-lang-js>
 
-There is also a [GLib]/[GObject] based [toolkit][ev3devKit] that provides a number of
-programming interfaces for ev3dev, including user interface and device driver
-interface.  It is written in vala, but since it uses GObjects, it can be used
-with many [languages] via [GObjectIntrospection]. The [Brick Manager][brickman]
+JavaScript is the scripting language of the Web. With a program called Node.js, you can write JavaScript that can be run locally like any other scripting language.
+JavaScript with Node.js is great for writing web servers and other asynchronous programs which don't need to run tight loops or precise timers. It has a syntax similar to that of C and related
+languages, and is relatively easy to learn.
+
+[Get started with JavaScript](https://github.com/wasabifan/ev3dev-lang-js){: .btn .btn-default }
+
+## Go
+<https://github.com/ev3go/ev3dev>
+
+Go is a compiled, statically-typed language created by at Google. It aims to be simple and light while still providing modern language features.
+
+[Get started with Go](https://github.com/ev3go/ev3dev){: .btn .btn-default }
+
+## C++
+<https://github.com/ddemidov/ev3dev-lang-cpp>
+
+C++ is a low-level, compiled language which is highly performant while still providing modern language features. It is best for applications which require the fastest execution or
+interaction with existing C++ libraries.
+
+[Get started with C++](https://github.com/ddemidov/ev3dev-lang-cpp){: .btn .btn-default }
+
+## C
+<https://github.com/in4lio/ev3dev-c>
+
+C is a low-level, compiled language which is useful for interacting with other C-based code. It is very lightweight and often the most portable across platforms.
+
+[Get started with C](https://github.com/in4lio/ev3dev-c){: .btn .btn-default }
+
+
+## Vala, Genie and other GObject-based languages with ev3devKit
+<https://github.com/ev3dev/ev3devKit>
+
+Through [GObject-introspection](https://wiki.gnome.org/Projects/GObjectIntrospection), this library can be used by languages including Vala and Genie, among [many others](https://wiki.gnome.org/Projects/GObjectIntrospection/Users).
+This is great for people who want to use higher-level syntax while still producing a performant application, or people who want a less error-prone API for C. The [Brick Manager][https://github.com/ev3dev/brickman]
 for ev3dev is written using this library.
 
-[ev3devKit]: https://github.com/ev3dev/ev3devKit
-[GLib]: https://developer.gnome.org/glib/stable/index.html
-[GObject]: https://developer.gnome.org/gobject/stable/index.html
-[languages]: https://wiki.gnome.org/Projects/GObjectIntrospection/Users
-[GObjectIntrospection]: https://wiki.gnome.org/Projects/GObjectIntrospection
-[brickman]: https://github.com/ev3dev/brickman
+[Get started with ev3devKit](https://github.com/ev3dev/ev3devKit){: .btn .btn-default }
 
-## Extra languages
-We also have many great contrubutors that are maintaining extra libraries for
-languages not included in our other repository.  Note that some of these
-libraries may be outdated due to the fast development pace of ev3dev.
+--------
 
-* Extra languages:
-    * [Go](https://github.com/ldmberman/GoEV3) updated for ev3dev-jessie by @ldmberman, [original](https://github.com/mattrajca/GoEV3) by @mattrajca
-    * [Go](https://github.com/ev3go/ev3dev) closely following the ev3dev API specification by the @ev3go project.
-    * [Java](https://github.com/ev3dev-lang-java/ev3dev-lang-java) an interface similar to that of LeJOS by @jabrena
-    * [Python](https://github.com/topikachu/python-ev3) by @topikachu
-    * [C (with optional Perl, Python and Ruby bindings)](https://github.com/in4lio/ev3dev-c) by @in4lio
-    * [C](https://github.com/theZiz/ev3c) by @theZiz
-    * [Clojure](https://github.com/annapawlicka/clj-ev3dev) by @annapawlicka
+{% include icon.html type="danger" %}
+Listings below this point are for libraries that are either not up-to-date or have been abandoned. Use them with caution, as functionality will likely be broken.
+{: .alert .alert-danger}
+
+## Pure Java
+<https://github.com/mob41/ev3dev-lang-java>
+
+## Java LeJOS compatibility layer
+<https://github.com/ev3dev-lang-java/ev3dev-lang-java>
+
+## Clojure
+<https://github.com/annapawlicka/clj-ev3dev>
+
+## Python (alternative library)
+<https://github.com/topikachu/python-ev3>
+
+## Go (alternative library)
+<https://github.com/ldmberman/GoEV3>
+
+## C (alternative library)
+<https://github.com/theZiz/ev3c>


### PR DESCRIPTION
This makes it less about politics and implementation and more about the things that a user needs to know.

I sorted the languages in order of ease-of-use; essentially, they are in the order a beginner should see them in. I figure that if an expert is reading the page, the order won't matter, because they will find a specific section directly anyways. I wasn't really sure where to put ev3devKit, as languages like Vala are easy to use but setting up a compiler is more difficult, in addition to the fact that -- due to the nature of it -- there aren't any language-specific instructions.

~~Note that I decided to put <https://github.com/mob41/ev3dev-lang-java> in the "not up-to-date" section because it does not support recent drivers, but there has been activity in the last few days from the author saying that they have been busy but plan to get it updated. That library might need to be moved to the other section if/when that happens.~~ ~~Edit: Not only were changes just pushed to that repo (2 minutes ago as of this edit), but the kernel that was most recently supported was a version that included all significant breaking changes so far. So, I think I will need to move this into the other section and add a description.~~ Edit 2: Nevermind. https://github.com/mob41/ev3dev-lang-java/commit/bdb5b8924629d4cba1c59ada50a8c67d7e26da7c.

Preview here: http://wasabifan.github.io/ev3dev.github.io/docs/libraries/.

ev3dev/ev3dev#733