### PR TITLE
Clarify intent of the "projects" page

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -1,11 +1,11 @@
 ---
-title: Projects
-excerpt: "This is where we keep a collection of some of the projects that people are working on using ev3dev. We invite you to click through the links below to see what cool stuff ev3dev can do!"
+title: Project Showcase
+excerpt: "This is where we keep a collection of some of the most interesting projects that people are working on using ev3dev. We invite you to click through the links below to see what cool stuff ev3dev can do!"
 include_masonry: "true"
 ---
 
 <p class="lead">
-    This is where we keep a collection of some of the projects that people are working
+    This is where we keep a collection of some of the most interesting projects that people are working
     on using ev3dev. We invite you to click through the links below to see what
     cool stuff ev3dev can do!
 </p>


### PR DESCRIPTION
These changes rename the page to "Project showcase" and adds some clearer language to the intro paragraph. It now reads:

> This is where we keep a collection of some of the most interesting projects that people are working on using ev3dev. We invite you to click through the links below to see what cool stuff ev3dev can do!

I'm not sure if there needs to be added wording which explicitly says that these projects might not be easy to replicate. @dlech @ndward thoughts?

Fixes ev3dev/ev3dev#732