### PR TITLE
Add SSH tutorial and remove mentions of empty page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -240,6 +240,10 @@ to connect for the first time. You can setup additional connections using the
 `connmanctl` command.
 {: class="alert alert-info"}
 
+Now that you have a network connection, you should
+[connect to your EV3 with SSH](/docs/tutorials/connecting-to-ev3dev-with-ssh)
+if you haven't done so already.
+
 </div>
 </div>
 

--- a/docs/tutorials/connecting-to-ev3dev-with-ssh.md
+++ b/docs/tutorials/connecting-to-ev3dev-with-ssh.md
@@ -3,6 +3,10 @@ title: Connecting to Ev3dev Using SSH
 subject: Networking
 ---
 
+Connecting with SSH will allow you to run commands on the EV3 over the network
+so that you can deploy code, change settings, and install tools. Make sure that
+you have configured a network connection before continuing.
+
 *   {: tab="Mac OSX"}
     OS X supports the good old `ssh` program. In a terminal, run the following command
     to use it to connect to your EV3 or other ev3dev device.

--- a/docs/tutorials/connecting-to-ev3dev-with-ssh.md
+++ b/docs/tutorials/connecting-to-ev3dev-with-ssh.md
@@ -1,0 +1,124 @@
+---
+title: Connecting to Ev3dev Using SSH
+subject: Networking
+---
+
+*   {: tab="Mac OSX"}
+    OS X supports the good old `ssh` program. In a terminal, run the following command
+    to use it to connect to your EV3 or other ev3dev device.
+
+        ssh robot@ev3dev.local
+
+    <div class="panel panel-info">
+    <div class="panel-heading">
+    {% include icon.html type="info" %}
+    If you have never connected before, you will be prompted to confirm the
+    authenticity of the host, so type <code>yes</code> when prompted.
+    </div>
+    <div class="panel-body">
+    <pre>
+        The authenticity of host 'ev3dev.local (192.168.2.3)' can't be established.
+        RSA key fingerprint is xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx.
+        Are you sure you want to continue connecting (yes/no)? yes
+        Warning: Permanently added 'ev3dev.local' (RSA) to the list of known hosts.
+    </pre>
+    </div>
+    </div>
+
+    Enter your password when prompted. The default password is `maker`.
+
+        robot@ev3dev's password: 
+                     _____     _
+           _____   _|___ /  __| | _____   __
+          / _ \ \ / / |_ \ / _` |/ _ \ \ / /
+         |  __/\ V / ___) | (_| |  __/\ V /
+          \___| \_/ |____/ \__,_|\___| \_/
+        
+        Debian jessie on LEGO MINDSTORMS EV3!
+        
+        The programs included with the Debian GNU/Linux system are free software;
+        the exact distribution terms for each program are described in the
+        individual files in /usr/share/doc/*/copyright.
+        
+        Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
+        permitted by applicable law.
+        robot@ev3dev:~$ 
+
+*   {: tab="Ubuntu"}
+    Type the following command in a terminal window.
+
+        ssh robot@ev3dev.local
+
+    <div class="panel panel-info">
+    <div class="panel-heading">
+    {% include icon.html type="info" %}
+    If you have never connected before, you will be prompted to confirm the
+    authenticity of the host, so type <code>yes</code> when prompted.
+    </div>
+    <div class="panel-body">
+    <pre>
+        The authenticity of host 'ev3dev.local (10.42.0.228)' can't be established.
+        ECDSA key fingerprint is SHA256:LjEw+uEG5x7kl9LwVeynjeybuBHT3VQB5simpcVqmu8.
+        Are you sure you want to continue connecting (yes/no)? yes
+        Warning: Permanently added 'ev3dev.local,10.42.0.228' (ECDSA) to the list of known hosts.
+        Warning: Permanently added '10.42.0.228' (ECDSA) to the list of known hosts.
+    </pre>
+    </div>
+    </div>
+
+    Enter your password when prompted. The default password is `maker`.
+
+        robot@ev3dev.local's password: 
+                     _____     _
+           _____   _|___ /  __| | _____   __
+          / _ \ \ / / |_ \ / _` |/ _ \ \ / /
+         |  __/\ V / ___) | (_| |  __/\ V /
+          \___| \_/ |____/ \__,_|\___| \_/
+
+        Debian jessie on LEGO MINDSTORMS EV3!
+
+        The programs included with the Debian GNU/Linux system are free software;
+        the exact distribution terms for each program are described in the
+        individual files in /usr/share/doc/*/copyright.
+
+        Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
+        permitted by applicable law.
+        robot@ev3dev:~$ 
+
+
+*   {: tab="Windows"}
+    To connect via SSH on Windows, you will need a program called [PuTTY].
+    Download and run it from [their download page][PuTTY download]. In the
+    *PuTTY Configuration* window, type in `ev3dev` for the "host name".
+    Then click the *Open* button to connect.
+
+    {% include screenshot.html source="/images/windows/10/putty-configuration-ev3dev.png" %}
+
+    <div class="panel panel-info">
+    <div class="panel-heading">
+
+    {% include icon.html type="info" %}
+    The first time you connect, you'll get a warning about the new fingerprint.
+    This is normal. Just click *Yes* to continue. You won't see this again
+    unless you re-flash your SD card.
+
+    </div>
+    <div class="panel-body">
+    {% include screenshot.html source="/images/windows/10/putty-security-alert.png" %}
+    </div>
+    </div>
+
+    Once you are connected, type in the ev3dev username (`robot`) and the password
+    (`maker` if you haven't changed it yet) and then you should be logged in.
+
+    {% include screenshot.html source="/images/windows/10/putty-robot-at-ev3dev.png" %}
+
+    {% include icon.html type="success" %}
+    Pro tip! You can copy text by selecting it (dragging accross it with your cursor)
+    and paste by right-clicking on the PuTTY window.
+    {: .alert .alert-success }
+{: tab-list="os"}
+
+
+[PuTTY]: http://www.chiark.greenend.org.uk/%7Esgtatham/putty/
+[PuTTY download]: http://www.chiark.greenend.org.uk/~sgtatham/putty/

--- a/docs/tutorials/connecting-to-the-internet-via-bluetooth.md
+++ b/docs/tutorials/connecting-to-the-internet-via-bluetooth.md
@@ -3,13 +3,6 @@ title: Connecting to the Internet via Bluetooth
 subject: Networking
 ---
 
-{% include icon.html type="info" %}
-If you do not need to access the Internet from the EV3 brick, consider
-using [tethering]{: .alert-link} instead.
-{: .alert .alert-info}
-
-[tethering]: /docs/tutorials/using-bluetooth-tethering
-
 {% include icon.html type="warning" %}
 These instructions are for [brickman v0.7.0](/news/2015/12/15/Package-Release/){: .alert-link}.
 If you are using an older version, please upgrade.
@@ -190,46 +183,6 @@ If you are using an older version, please upgrade.
 
         {% include screenshot.html source="/images/brickman/networking-my-computer-0-disconnect-selected-online.png" %}
 
-    15. For `ssh` access to the EV3 under OS X, you can use the good old `ssh`
-        program in Terminal. In a terminal, run the following command.
-
-            ssh robot@ev3dev.local
-
-        <div class="panel panel-info">
-        <div class="panel-heading">
-        {% include icon.html type="info" %}
-        If you have never connected before, you will prompted to confirm the
-        authenticity of the host, so type `yes` when prompted.
-        </div>
-        <div class="panel-body">
-        <pre>
-            The authenticity of host 'ev3dev.local (192.168.2.3)' can't be established.
-            RSA key fingerprint is xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx.
-            Are you sure you want to continue connecting (yes/no)? yes
-            Warning: Permanently added '192.168.2.3' (RSA) to the list of known hosts.
-        </pre>
-        </div>
-        </div>
-
-    16. Enter your password. The default password is `maker`.
-
-            robot@ev3dev's password: 
-                         _____     _
-               _____   _|___ /  __| | _____   __
-              / _ \ \ / / |_ \ / _` |/ _ \ \ / /
-             |  __/\ V / ___) | (_| |  __/\ V /
-              \___| \_/ |____/ \__,_|\___| \_/
-            
-            Debian jessie on LEGO MINDSTORMS EV3!
-            
-            The programs included with the Debian GNU/Linux system are free software;
-            the exact distribution terms for each program are described in the
-            individual files in /usr/share/doc/*/copyright.
-            
-            Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
-            permitted by applicable law.
-            robot@ev3dev:~$ 
-
 *   {: tab="Ubuntu"}{% include icon.html type="info" %}
     These instructions were written using Ubuntu 16.04 and the default desktop.
     It should work for other versions of Ubuntu, derivatives of Ubuntu and
@@ -302,45 +255,9 @@ If you are using an older version, please upgrade.
 
         {% include screenshot.html source="/images/brickman/networking-my-computer-0-disconnect-selected-online.png" %}
 
-    9.  Now we are going to connect to the EV3 using ssh. In a terminal, run the
-        following command.
-
-            ssh robot@ev3dev.local
-
-        <div class="panel panel-info">
-        <div class="panel-heading">
-        {% include icon.html type="info" %}
-        If you have never connected before, you will prompted to confirm the
-        authenticity of the host, so type `yes` when prompted.
-        </div>
-        <div class="panel-body">
-        <pre>
-            The authenticity of host '10.25.9.98 (10.25.9.98)' can't be established.
-            ECDSA key fingerprint is be:9e:66:8b:d1:14:b8:8a:ea:4c:6e:07:2d:d9:68:05.
-            Are you sure you want to continue connecting (yes/no)? yes
-            Warning: Permanently added '10.25.9.98' (ECDSA) to the list of known hosts.
-        </pre>
-        </div>
-        </div>
-
-    10. Enter your password when prompted. The default password is `maker`.
-
-            robot@ev3dev's password: 
-                         _____     _
-               _____   _|___ /  __| | _____   __
-              / _ \ \ / / |_ \ / _` |/ _ \ \ / /
-             |  __/\ V / ___) | (_| |  __/\ V /
-              \___| \_/ |____/ \__,_|\___| \_/
-            
-            Debian jessie on LEGO MINDSTORMS EV3!
-            
-            The programs included with the Debian GNU/Linux system are free software;
-            the exact distribution terms for each program are described in the
-            individual files in /usr/share/doc/*/copyright.
-            
-            Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
-            permitted by applicable law.
-            robot@ev3dev:~$ 
-
 *   {: tab="Windows"}__HELP WANTED!__ See [issue #287](https://github.com/ev3dev/ev3dev/issues/287).
 {: tab-list="os"}
+
+Now that you have a network connection, you should
+[connect to your EV3 with SSH](/docs/tutorials/connecting-to-ev3dev-with-ssh)
+if you haven't done so already.

--- a/docs/tutorials/connecting-to-the-internet-via-usb.md
+++ b/docs/tutorials/connecting-to-the-internet-via-usb.md
@@ -3,15 +3,8 @@ title: Connecting to the Internet via USB
 subject: Networking
 ---
 
-{% include icon.html type="info" %}
-If you do not need to access the Internet from the EV3 brick, consider
-using [tethering]{: .alert-link} instead.
-{: class="alert alert-info"}
-
-[tethering]: /docs/tutorials/using-usb-tethering
-
 {% include icon.html type="warning" %}
-These instructions are for [brickman v0.7.0](/news/2015/12/15/Package-Release/){: .alert-link}.
+These instructions are for [brickman v0.7.0](/news/2015/12/15/Package-Release/){: .alert-link} and later.
 If you are using an older version, please upgrade.
 {: .alert .alert-warning}
 
@@ -72,46 +65,6 @@ If you are using an older version, please upgrade.
         in the future.
 
         {% include screenshot.html source="/images/brickman/wired-status-online-connect-automatically-selected.png" %}
-
-    9.  For `ssh` access to the EV3 under OS X, you can use the good old `ssh`
-        program from the terminal window. In a terminal, run the following command.
-
-            ssh robot@ev3dev.local
-
-        <div class="panel panel-info">
-        <div class="panel-heading">
-        {% include icon.html type="info" %}
-        If you have never connected before, you will be prompted to confirm the
-        authenticity of the host, so type `yes` when prompted.
-        </div>
-        <div class="panel-body">
-        <pre>
-            The authenticity of host 'ev3dev.local (192.168.2.3)' can't be established.
-            RSA key fingerprint is xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx.
-            Are you sure you want to continue connecting (yes/no)? yes
-            Warning: Permanently added 'ev3dev.local' (RSA) to the list of known hosts.
-        </pre>
-        </div>
-        </div>
-
-    10. Enter your password when prompted. The default password is `maker`.
-
-            robot@ev3dev's password: 
-                         _____     _
-               _____   _|___ /  __| | _____   __
-              / _ \ \ / / |_ \ / _` |/ _ \ \ / /
-             |  __/\ V / ___) | (_| |  __/\ V /
-              \___| \_/ |____/ \__,_|\___| \_/
-            
-            Debian jessie on LEGO MINDSTORMS EV3!
-            
-            The programs included with the Debian GNU/Linux system are free software;
-            the exact distribution terms for each program are described in the
-            individual files in /usr/share/doc/*/copyright.
-            
-            Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
-            permitted by applicable law.
-            robot@ev3dev:~$ 
 
 *   {: tab="Ubuntu"}{% include icon.html type="info" %}
     These instructions were written using Ubuntu 15.10 and the default desktop
@@ -175,48 +128,6 @@ If you are using an older version, please upgrade.
         in the future.
 
         {% include screenshot.html source="/images/brickman/wired-status-online-connect-automatically-selected.png" %}
-
-    10. Now we are going to connect to the EV3 using ssh. Type the following
-        command in a terminal window.
-
-            ssh robot@ev3dev.local
-
-        <div class="panel panel-info">
-        <div class="panel-heading">
-        {% include icon.html type="info" %}
-        If you have never connected before, you will be prompted to confirm the
-        authenticity of the host, so type `yes` when prompted.
-        </div>
-        <div class="panel-body">
-        <pre>
-            The authenticity of host 'ev3dev.local (10.42.0.228)' can't be established.
-            ECDSA key fingerprint is SHA256:LjEw+uEG5x7kl9LwVeynjeybuBHT3VQB5simpcVqmu8.
-            Are you sure you want to continue connecting (yes/no)? yes
-            Warning: Permanently added 'ev3dev.local,10.42.0.228' (ECDSA) to the list of known hosts.
-            Warning: Permanently added '10.42.0.228' (ECDSA) to the list of known hosts.
-        </pre>
-        </div>
-        </div>
-
-    11. Enter your password when prompted. The default password is `maker`.
-
-            robot@ev3dev.local's password: 
-                         _____     _
-               _____   _|___ /  __| | _____   __
-              / _ \ \ / / |_ \ / _` |/ _ \ \ / /
-             |  __/\ V / ___) | (_| |  __/\ V /
-              \___| \_/ |____/ \__,_|\___| \_/
-
-            Debian jessie on LEGO MINDSTORMS EV3!
-
-            The programs included with the Debian GNU/Linux system are free software;
-            the exact distribution terms for each program are described in the
-            individual files in /usr/share/doc/*/copyright.
-
-            Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
-            permitted by applicable law.
-            robot@ev3dev:~$ 
-
 
 *   {: tab="Windows"}{% include icon.html type="info" %}
     These instructions were written using Windows 10, but should work on Windows
@@ -324,26 +235,6 @@ If you are using an older version, please upgrade.
         *Online* to indicate that your EV3 is connected to the Internet.
 
         {% include screenshot.html source="/images/brickman/wired-status-online-connect-selected.png" %}
-
-    16. Now we are going to connect to the EV3 using ssh. To do this, you need a
-        program called [PuTTY]. Start PuTTY. In the *PuTTY Configuration* window,
-        type in `ev3dev`. Then click the *Open* button to connect.
-
-        {% include screenshot.html source="/images/windows/10/putty-configuration-ev3dev.png" %}
-
-        {% include icon.html type="info" %}
-        The first time you connect, you'll get a warning about the new fingerprint.
-        This is normal. Just click *Yes* to continue. You won't see this again
-        unless you re-flash your SD card.
-        {% include screenshot.html source="/images/windows/10/putty-security-alert.png" %}
-        {: class="alert alert-info"}
-
-        Once you are connected, type in your username (`robot`) and your password
-        (`maker` if you haven't changed it yet) and then you should be logged in.
-
-        {% include screenshot.html source="/images/windows/10/putty-robot-at-ev3dev.png" %}
 {: tab-list="os"}
 
-
-[PuTTY]: http://www.chiark.greenend.org.uk/%7Esgtatham/putty/
 [linux.inf]: https://raw.githubusercontent.com/ev3dev/ev3-kernel/ev3dev-jessie/Documentation/usb/linux.inf

--- a/docs/tutorials/connecting-to-the-internet-via-usb.md
+++ b/docs/tutorials/connecting-to-the-internet-via-usb.md
@@ -238,3 +238,7 @@ If you are using an older version, please upgrade.
 {: tab-list="os"}
 
 [linux.inf]: https://raw.githubusercontent.com/ev3dev/ev3-kernel/ev3dev-jessie/Documentation/usb/linux.inf
+
+Now that you have a network connection, you should
+[connect to your EV3 with SSH](/docs/tutorials/connecting-to-ev3dev-with-ssh)
+if you haven't done so already.

--- a/docs/tutorials/using-bluetooth-tethering.md
+++ b/docs/tutorials/using-bluetooth-tethering.md
@@ -79,46 +79,6 @@ If you are using an older version, please upgrade.
 
         {% include screenshot.html source="/images/osx/10.10/System-Preferences-Network-Bluetooth-PAN-Connected.png" %}
 
-    11. For `ssh` access to the EV3 under OS X, you can use the good old `ssh`
-        program from the terminal window. In a terminal, run the following command.
-
-            ssh robot@ev3dev.local
-
-        <div class="panel panel-info">
-        <div class="panel-heading">
-        {% include icon.html type="info" %}
-        If you have never connected before, you will prompted to confirm the
-        authenticity of the host, so type `yes` when prompted.
-        </div>
-        <div class="panel-body">
-        <pre>
-            The authenticity of host '192.168.1.1 (192.168.1.1)' can't be established.
-            RSA key fingerprint is xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx.
-            Are you sure you want to continue connecting (yes/no)? yes
-            Warning: Permanently added '192.168.1.1' (RSA) to the list of known hosts.
-        </pre>
-        </div>
-        </div>
-
-    12. Enter your password when prompted. The default password is `maker`.
-
-            robot@ev3dev's password: 
-                         _____     _
-               _____   _|___ /  __| | _____   __
-              / _ \ \ / / |_ \ / _` |/ _ \ \ / /
-             |  __/\ V / ___) | (_| |  __/\ V /
-              \___| \_/ |____/ \__,_|\___| \_/
-            
-            Debian jessie on LEGO MINDSTORMS EV3!
-            
-            The programs included with the Debian GNU/Linux system are free software;
-            the exact distribution terms for each program are described in the
-            individual files in /usr/share/doc/*/copyright.
-            
-            Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
-            permitted by applicable law.
-            robot@ev3dev:~$ 
-
 *   {: tab="Ubuntu"}
     {% include icon.html type="warning" %}
     HELP WANTED! See [issue #287](https://github.com/ev3dev/ev3dev/issues/287){: .alert-link}.
@@ -143,3 +103,7 @@ If you are using an older version, please upgrade.
         We just need someone to make it pretty.
     {: tab-list="os-version"}
 {: tab-list="os"}
+
+Now that you have a network connection, you should
+[connect to your EV3 with SSH](/docs/tutorials/connecting-to-ev3dev-with-ssh)
+if you haven't done so already.


### PR DESCRIPTION
Fixes ev3dev/ev3dev#727

Preview at http://wasabifan.github.io/ev3dev.github.io/docs/tutorials/connecting-to-ev3dev-with-ssh/.

Also, can we remove the "these instructions are for..." version warning message? The December image has been in the wild for almost ten months at this point, so I doubt that anyone is using an image from before that. It isn't a big deal, but it would be nice to remove an alert from that page if it isn't needed anymore.
