### PR TITLE
Bump Ruby CI version to 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.1
+- 2.2.2
 
 before_script:
  - chmod +x ./cibuild.sh # or do this locally and commit


### PR DESCRIPTION
This fixes a CI server build error because one of the gems we depend on bumped their required Ruby version.