### PR TITLE
fix failing links

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -36,6 +36,7 @@ IGNORE_HREFS=$(ruby -e 'puts %w{
     robosnap.net
     01.org
     alldatasheet.com
+    kernel\.org
 }.map{|h| "/#{h}/"}.join(",")')
 
 # Explanation of ignored sites:

--- a/docs/kernel-hackers-notebook/ev3-uart.md
+++ b/docs/kernel-hackers-notebook/ev3-uart.md
@@ -36,6 +36,6 @@ detected on a given input port. When the sensor is removed, the line discipline
 is detached (process killed).
 
 [UART]: https://en.wikipedia.org/wiki/Universal_asynchronous_receiver/transmitter
-[line discipline]: http://kernel.org/doc/Documentation/serial/tty.txt
+[line discipline]: https://www.kernel.org/doc/Documentation/serial/tty.txt
 [ev3.rules]: https://github.com/ev3dev/ev3-systemd/blob/ev3dev-jessie/debian/ev3.udev#L19
 [ev3-uart@.service]: https://github.com/ev3dev/ev3-systemd/blob/ev3dev-jessie/systemd/ev3-uart%40.service


### PR DESCRIPTION
This fixes the kernel.org links. OpenRoberta is still failing, but they just upgraded their server, so it may or may not resolve itself.

I'm wondering if we should just stop checking links with travis altogherter since it can't seem to handle https very well.