### PR TITLE
Rename "Get Help" to "Support"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -44,7 +44,7 @@
                         </ul>
                     </li>
                     <li>
-                        <a href="/support" title="Support for problems with the ev3dev ecosystem">Get Help</a>
+                        <a href="/support" title="Get Help with ev3dev">Support</a>
                     </li>
                     <li>
                         <a href="/news" title="ev3dev news">News</a>

--- a/support.md
+++ b/support.md
@@ -1,5 +1,5 @@
 ---
-title: "Get Help"
+title: "Support"
 redirect_from: /issues/index.html
 excerpt: "Have a problem or question? We are here to help - but you have to help us help you. We keep track of problems, suggestions and questions about ev3dev using GitHub Issues. This lets us keep everything in one place."
 ---


### PR DESCRIPTION
This is more conventional and in the menu bar it is better to have
all items as nouns, not a mix of nouns and verbs.