### PR TITLE
Remove Home from main navbar

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,9 +14,6 @@
             <div class="collapse navbar-collapse">
                 <ul class="nav navbar-nav" id="main-nav">
                     <li>
-                        <a href="/" title="There's no place like Home...">Home</a>
-                    </li>
-                    <li>
                         <a href="/docs/getting-started" title="Our Getting Started guide">Start Here</a>
                     </li>
                     <li class="dropdown">


### PR DESCRIPTION
It is redundant since clicking on the ev3dev.org logo takes
you to the same page.