### PR TITLE
Add missing "div.row"s to project and news pages

### DIFF
--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -11,26 +11,27 @@ layout: page
         {% endif %}
     {% endif %}
 {% endfor %}
-
-<div class="col-lg-9">
-    {{ content }}
-</div>
-<div class="col-lg-3">
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">Post Info</h3>
+<div class="row">
+    <div class="col-lg-9">
+        {{ content }}
+    </div>
+    <div class="col-lg-3">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Post Info</h3>
+            </div>
+            <ul class="list-group">
+                <li class="list-group-item">
+                    Posted on {{ page.date | date_to_long_string  }}
+                </li>
+                {% if page.author %}
+                <li class="list-group-item">
+                    {% for author in page.author %}
+                    {% include author-card.html author=author %}
+                    {% endfor %}
+                </li>
+                {% endif %}
+            </ul>
         </div>
-        <ul class="list-group">
-            <li class="list-group-item">
-                Posted on {{ page.date | date_to_long_string  }}
-            </li>
-            {% if page.author %}
-            <li class="list-group-item">
-                {% for author in page.author %}
-                {% include author-card.html author=author %}
-                {% endfor %}
-            </li>
-            {% endif %}
-        </ul>
     </div>
 </div>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -2,43 +2,45 @@
 layout: page
 ---
 
-<div class="col-lg-9">
-    {% include youtube-embed.html %}
-    {{ content }}
-</div>
-<div class="col-lg-3">
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">Project Info</h3>
+<div class="row">
+    <div class="col-lg-9">
+        {% include youtube-embed.html %}
+        {{ content }}
+    </div>
+    <div class="col-lg-3">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Project Info</h3>
+            </div>
+            <ul class="list-group">
+                {% if page.programming_language %}
+                <li class="list-group-item">
+                    Written with {% include language-logo.html language=page.programming_language %}<br />
+                </li>
+                {% endif %}
+                {% if page.project_homepage_url %}
+                <li class="list-group-item">
+                    <a class="btn btn-primary" href="{{ page.project_homepage_url }}">Project homepage</a>
+                </li>
+                {% endif %}
+                {% if page.building_instructions_url %}
+                <li class="list-group-item">
+                    <a class="btn btn-primary" href="{{ page.building_instructions_url }}">Building instructions</a>
+                </li>
+                {% endif %}
+                {% if page.source_code_url %}
+                <li class="list-group-item">
+                    <a class="btn btn-primary" href="{{ page.source_code_url }}">Source code</a>
+                </li>
+                {% endif %}
+                {% if page.author %}
+                <li class="list-group-item">
+                    {% for author in page.author %}
+                    {% include author-card.html author = author %}
+                    {% endfor %}
+                </li>
+                {% endif %}
+            </ul>
         </div>
-        <ul class="list-group">
-            {% if page.programming_language %}
-            <li class="list-group-item">
-                Written with {% include language-logo.html language=page.programming_language %}<br />
-            </li>
-            {% endif %}
-            {% if page.project_homepage_url %}
-            <li class="list-group-item">
-                <a class="btn btn-primary" href="{{ page.project_homepage_url }}">Project homepage</a>
-            </li>
-            {% endif %}
-            {% if page.building_instructions_url %}
-            <li class="list-group-item">
-                <a class="btn btn-primary" href="{{ page.building_instructions_url }}">Building instructions</a>
-            </li>
-            {% endif %}
-            {% if page.source_code_url %}
-            <li class="list-group-item">
-                <a class="btn btn-primary" href="{{ page.source_code_url }}">Source code</a>
-            </li>
-            {% endif %}
-            {% if page.author %}
-            <li class="list-group-item">
-                {% for author in page.author %}
-                {% include author-card.html author = author %}
-                {% endfor %}
-            </li>
-            {% endif %}
-        </ul>
     </div>
 </div>


### PR DESCRIPTION
GitHub's diff is pretty ugly, but all this does is wrap these sets of columns into `div.row`s to make things aligned properly. At some point these were removed/changed but I have no idea when (nor do I really care).