### PR TITLE
switch to x3dom 1.7.1 until problems in 1.7.2 are worked out

### DIFF
--- a/_includes/page-core/deferred-head-resources.html
+++ b/_includes/page-core/deferred-head-resources.html
@@ -1,8 +1,8 @@
 {% if page.enable_x3d_support %}
 <!-- X3D styles and scripts -->
 <!-- x3dom.js is nearly 1 MB of data so we only include it if necessary  -->
-<link rel='stylesheet' type='text/css' href='http://www.x3dom.org/download/x3dom.css'>
-<script type='text/javascript' src='http://www.x3dom.org/download/x3dom.js'></script>
+<link rel='stylesheet' type='text/css' href='http://www.x3dom.org/download/1.7.1/x3dom.css'>
+<script type='text/javascript' src='http://www.x3dom.org/download/1.7.1/x3dom.js'></script>
 {% endif %}
 
 <!-- Custom styles -->


### PR DESCRIPTION
in recently released (19.12.2016)  1.7.2 x3dom src loading is broken

this fixes x3dom library to 1.7.1 version until I have time to migrate
x3d models and files to glb format or x3dom src loading is corrected

The x3dom [issue](https://github.com/x3dom/x3dom/issues/695) for reference
