### PR TITLE
"Humanize" breadcrumbs and improve misc formatting

### DIFF
--- a/_data/breadcrumbs.yml
+++ b/_data/breadcrumbs.yml
@@ -1,0 +1,16 @@
+docs:
+  name: "Documentation"
+  devtools:
+    name: Developer Tools
+  drivers:
+    name: Kernel Drivers
+  kernel-hackers-notebook:
+    name: Kernel Hacker's Notebook
+  motors:
+    name: Motors
+  ports:
+    name: Input and Output Ports
+  sensors:
+    name: Sensors
+  tutorials:
+    name: Tutorials

--- a/_includes/page-core/breadcrumbs.html
+++ b/_includes/page-core/breadcrumbs.html
@@ -7,24 +7,24 @@
     {% for dir in parent_dirs %}
         {% assign link=link | append: dir | append: '/' %}
 
-        {% assign humanized_name = dir %}
+        {% assign pretty_name = dir %}
         {% if forloop.last %}
             {% assign itemElem = 'span' %}
             {% assign liClass = 'active' %}
-            {% assign humanized_name = page.title %}
+            {% assign pretty_name = page.title %}
         {% else %}
             {% assign itemElem = 'a' %}
             {% assign hrefAttrib = 'href="' | append: link | append: '"' %}
 
             {% assign current_dir = current_dir[dir] %}
             {% if current_dir.name %}
-                {% assign humanized_name = current_dir.name %}
+                {% assign pretty_name = current_dir.name %}
             {% endif %}
         {% endif %}
 
         <li property="itemListElement" typeof="ListItem" class="{{liClass}}">
             <{{itemElem}} {{ hrefAttrib }} property="item" typeof="WebPage">
-                <span property="name">{{ humanized_name }}</span>
+                <span property="name">{{ pretty_name }}</span>
             </{{itemElem}}>
             <meta property="position" content="{{position}}">
         </li>

--- a/_includes/page-core/breadcrumbs.html
+++ b/_includes/page-core/breadcrumbs.html
@@ -2,19 +2,29 @@
 {% assign link='/' %}
 <ol class="breadcrumb" vocab="http://schema.org" typeof="BreadcrumbList">
     {% assign position = 1 %}
+    {% assign current_dir = site.data.breadcrumbs %}
+
     {% for dir in parent_dirs %}
         {% assign link=link | append: dir | append: '/' %}
+
+        {% assign humanized_name = dir %}
         {% if forloop.last %}
             {% assign itemElem = 'span' %}
             {% assign liClass = 'active' %}
+            {% assign humanized_name = page.title %}
         {% else %}
             {% assign itemElem = 'a' %}
             {% assign hrefAttrib = 'href="' | append: link | append: '"' %}
+
+            {% assign current_dir = current_dir[dir] %}
+            {% if current_dir.name %}
+                {% assign humanized_name = current_dir.name %}
+            {% endif %}
         {% endif %}
-        
+
         <li property="itemListElement" typeof="ListItem" class="{{liClass}}">
             <{{itemElem}} {{ hrefAttrib }} property="item" typeof="WebPage">
-                <span property="name">{{ dir }}</span>
+                <span property="name">{{ humanized_name }}</span>
             </{{itemElem}}>
             <meta property="position" content="{{position}}">
         </li>

--- a/contribute.md
+++ b/contribute.md
@@ -38,10 +38,10 @@ links works and the information is still relevant.
 As the hardware drivers are being finalized, development will be shifting to
 software that can interface with the hardware. There are many [packages on
 GitHub][ev3dev-github-org] that you can hack on. Additionally, there are some
-language bindings listed on the [home page](/) that are not part of the ev3dev
-GitHub organization (yet).
+language bindings listed on the [Programming Languages page](/docs/programming-languages)
+that would love some community support.
 
-If you have never used GitHub before, it's super-easy. [Read about it][GitHub Help],
+If you have never used GitHub before, it's super easy. [Read about it][GitHub Help],
 then send a pull request.
 
 ## Write a driver

--- a/docs/tutorials/adding-new-project.md
+++ b/docs/tutorials/adding-new-project.md
@@ -10,7 +10,7 @@ well as provide videos, pictures, build instructions, code, and any other media
 that pertains to the project. This is where we explain how you can submit your
 project page to be hosted on the site.
 
-##Overview
+## Overview
 
 All the projects on the website are stored in the [projects folder].
 Each post is saved as a Markdown file, and is automagically converted to HTML

--- a/docs/tutorials/using-ps3-sixaxis.md
+++ b/docs/tutorials/using-ps3-sixaxis.md
@@ -1,13 +1,15 @@
 ---
 title: Bluetooth PS3 gamepad in Python
 group: hardware-extras
-author: Anton Vanhoucke
+author: "@antonvh"
 ---
 
 * Table of Contents
 {:toc}
 
-The cool thing about the PS3 gamepad is that it's a normal Bluetooth device and connects directly to the Ev3. You can easily run programs in brickman and use the pad without another computer or laptop.
+The cool thing about the PS3 gamepad is that it's a normal Bluetooth device and
+connects directly to the EV3. You can easily run programs in brickman and use
+the pad without another computer or laptop.
 
 # What you need
 - A PS3 gamepad (also known as Sixaxis controller or Dualshock 3)
@@ -16,23 +18,31 @@ The cool thing about the PS3 gamepad is that it's a normal Bluetooth device and 
 - ev3-ev3dev-jessie-2015-12-30.img or later
 
 # Connection
-The PS3 pairing process in Brickman is a little strange, but works fine. Stick exactly to these steps: 
+The PS3 pairing process in Brickman is a little strange, but works fine. Stick
+exactly to these steps: 
 
 1. On the Ev3 brick go to 'Wireless and Networks' > 'Bluetooth'
 2. Make sure Bluetooth is Powered and the brick is Visible. 
-3. Connect the gamepad via a mini usb cable to the Ev3. I used the large usb port next to the micro SD slot.
+3. Connect the gamepad via a mini usb cable to the Ev3. I used the large usb
+    port next to the micro SD slot.
 4. Under Devices a 'PLAYSTATION(R) 3 controller' should show up. But don't pair!
 4. Remove the USB cable again.
 5. Press the PS3 button on the gamepad.
 6. The brick now asks "Authorize service HID?" Press "Accept" 
 
-You're done! Whenever you press the PS3 button on the gamepad now, it will try to connect to the ev3 brick. Nice!
+You're done! Whenever you press the PS3 button on the gamepad now, it will try
+to connect to the ev3 brick. Nice!
 
-If brickman doesn't work or if you don't have a display, like on a BrickPi, `bluetoothctl` is the way to go. The gentoo linux guys wrote [a nice tutorial](https://wiki.gentoo.org/wiki/Sony_DualShock)
+If brickman doesn't work or if you don't have a display, like on a BrickPi,
+`bluetoothctl` is the way to go. The gentoo linux guys wrote [a nice tutorial](https://wiki.gentoo.org/wiki/Sony_DualShock)
 
 
 # Running motors with a PS3 sixaxis controller
-Now on to Python. In python we need the evdev (without a 3) to read gamepad events. Here's a quick program that will take the right stick Y axis and use it to set the speed of a motor in port A. Note that motor control is in a separate thread. That's because controlling the motors is much slower than reading the gamepad. Multithreading synchronizes both.
+Now on to Python. In python we need the evdev (without a 3) to read gamepad
+events. Here's a quick program that will take the right stick Y axis and use it
+to set the speed of a motor in port A. Note that motor control is in a separate
+thread. That's because controlling the motors is much slower than reading the
+gamepad. Multithreading synchronizes both.
 
 {% highlight python %}
 #!/usr/bin/env python
@@ -98,7 +108,8 @@ for event in gamepad.read_loop():   #this loops infinitely
         break
 {% endhighlight %}
 
-Copy this code into a file on the Ev3 brick to run it. If you do `sudo chmod +x your_file_name.py`, you can even run it from the brickman interface!
+Copy this code into a file on the Ev3 brick to run it. If you do
+`sudo chmod +x your_file_name.py`, you can even run it from the brickman interface!
 
 # The complete event type and code mapping of the ps3 controller
 I mapped out all codes for you! Here they are:

--- a/projects/_posts/2014-08-20-EV3-simple-goodies.md
+++ b/projects/_posts/2014-08-20-EV3-simple-goodies.md
@@ -40,7 +40,7 @@ but with some simple edits you can place them where **you** want them.
 
 
 ### Have your EV3 report the IP-addresses by speach after boot 
-##### Starting at ev3dev image ev3dev-jessie-2014-10-07
+**Starting at ev3dev image ev3dev-jessie-2014-10-07**
 
 For this an update is needed to `/etc/rc.local`
 
@@ -57,7 +57,7 @@ fi
 and place the script [`tellIP`](https://github.com/BertLindeman/bert-ev3dev-examples/blob/master/tellIP)
 in the directory: `/media/mmc_p1/`
 
-##### OLDER ev3dev images (ev3dev-jessie-2014-10-07-12 and before)
+**OLDER ev3dev images (ev3dev-jessie-2014-10-07-12 and before)**
 
 For this an update is needed to `/media/mmc_p1/ev3dev.rc.local`
 

--- a/share.md
+++ b/share.md
@@ -1,6 +1,7 @@
 ---
 title: Share
 excerpt: "We have a projects page where users can browse projects that have been built using ev3dev. You can add your own too! Each project gets a dedicated page for the author to explain what they have been working on, as well as provide videos, pictures, build instructions, code, and any other media that pertains to the project."
+extra-head-content: '<script async defer src="https://buttons.github.io/buttons.js"></script>'
 ---
 <div class="lead">
     <center>
@@ -8,22 +9,22 @@ excerpt: "We have a projects page where users can browse projects that have been
     </center>
 </div>
 
-<div class="row">
-    <div class="col-md-6" markdown="1">
-<h3><span class="glyphicon glyphicon-star heading-icon"></span>Give us a star on GitHub</h3>
-"Stars" are a great way to show support for a GitHub project. Visit [ours][] and star us!
-</div>
-    <div class="col-md-6" markdown="1">
-<h3><span class="glyphicon glyphicon-check heading-icon"></span>Vote for ev3dev</h3>
-Vote for ev3dev in the [mindsensor.com][] poll (it's about half way down
-the page).
-</div>
-</div>
+Give us a star on GitHub
+---
 
-<hr/>
+<a class="github-button"
+    aria-label="Star ev3dev/ev3dev on GitHub"
+    href="https://github.com/ev3dev/ev3dev"
+    data-text="Visit us and star"
+    data-style="mega" data-icon="octicon-star"
+    data-count-href="/ev3dev/ev3dev/stargazers"
+    data-count-api="/repos/ev3dev/ev3dev#stargazers_count"
+    data-count-aria-label="# stargazers on GitHub">Star</a>
+
+"Stars" are a great way to show support for a GitHub project. Visit [ours][ev3dev-repo] and star us!
 
 Show us your ev3dev projects
-------------------------
+---
 
 We have a [projects page] where users can browse projects that have
 been built using ev3dev. You can add your own too!  Each project gets a
@@ -38,4 +39,4 @@ check out [the tutorial][Adding a new project].
 [template project]: https://raw.githubusercontent.com/ev3dev/ev3dev.github.io/master/projects/_posts/2014-03-21-Example-Project.md
 [template page]: /projects/2014/03/21/Example-Project/
 [Adding a new project]: ../docs/tutorials/adding-new-project/
-[ours]: https://github.com/ev3dev/ev3dev
+[ev3dev-repo]: https://github.com/ev3dev/ev3dev

--- a/share.md
+++ b/share.md
@@ -3,14 +3,14 @@ title: Share
 excerpt: "We have a projects page where users can browse projects that have been built using ev3dev. You can add your own too! Each project gets a dedicated page for the author to explain what they have been working on, as well as provide videos, pictures, build instructions, code, and any other media that pertains to the project."
 extra-head-content: '<script async defer src="https://buttons.github.io/buttons.js"></script>'
 ---
+
 <div class="lead">
     <center>
         Do you like ev3dev? Show your support!
     </center>
 </div>
 
-Give us a star on GitHub
----
+## Give us a star on GitHub
 
 <a class="github-button"
     aria-label="Star ev3dev/ev3dev on GitHub"
@@ -23,8 +23,7 @@ Give us a star on GitHub
 
 "Stars" are a great way to show support for a GitHub project. Visit [ours][ev3dev-repo] and star us!
 
-Show us your ev3dev projects
----
+## Show us your ev3dev projects
 
 We have a [projects page] where users can browse projects that have
 been built using ev3dev. You can add your own too!  Each project gets a

--- a/stylesheets/bootstrap.scss
+++ b/stylesheets/bootstrap.scss
@@ -68,3 +68,8 @@
 .panel-danger {
     @include panel-variant($panel-danger-heading-bg);
 }
+
+// Custom breadcrumb separator
+.breadcrumb > li + li::before {
+    content: ">"
+}

--- a/support.md
+++ b/support.md
@@ -4,9 +4,6 @@ redirect_from: /issues/index.html
 excerpt: "Have a problem or question? We are here to help - but you have to help us help you. We keep track of problems, suggestions and questions about ev3dev using GitHub Issues. This lets us keep everything in one place."
 ---
 
-* Table of Contents
-{:toc}
-
 <center>
 <h3>Have a problem or question?
     <br/>
@@ -21,12 +18,11 @@ We keep track of problems, suggestions and questions about ev3dev using [GitHub
 Issues]. This lets us keep everything in one place. (So, please don't email the
 developers directly unless you have a personal question.)
 
-First, before submitting an issue, search the existing issues (open and closed) to make sure someone else has
-not already reported the same problem or asked the same question. Please only
-comment on an existing **open** issue if you are fairly sure your problem/question is
-*exactly* the same. If the issue is closed or you are not sure your problem is the same,
-open a new issue instead. Be sure to mention any related issue by number and GitHub will
-magically create a link to it (e.g `#100`).
+First, before submitting an issue, search the existing issues (open and closed)
+to make sure someone else has not already reported the same problem or asked the
+same question. Please only comment on an existing **open** issue if you are
+fairly sure your problem/question is *exactly* the same. If the issue is closed
+or you are not sure your problem is the same, open a new issue instead.
 
 <br/>
 
@@ -40,8 +36,9 @@ magically create a link to it (e.g `#100`).
 </form>
 
 <small>
-__Note:__ The [ev3dev-lang]{:target="_blank"} repository has its own
-[issues][ev3dev-lang-issues]{:target="_blank"} tracker.
+__Note:__ The [ev3dev-lang-python]{:target="_blank"} repository has its own
+[issues][ev3dev-lang-python-issues]{:target="_blank"} tracker for Python-related
+questions.
 </small>
 
 <br/>
@@ -55,10 +52,11 @@ If you don't find anything helpful by searching, then create a [new issue]{:targ
 issue. If you are writing a program, post the code. If you are following
 a tutorial, which step failed? Be as detailed as possible.</strong>
 
-In the description of your issue, be sure to also include:
+In the description of your issue, **make sure to fill in the information from the template**.
+In addition, include as much relevant information as possible:
 
-  * The image file that you used to flash your SD card (e.g. `ev3dev-jessie-2015-02-24.img`).
-  * Your kernel version (output of `uname -rv`)
+  * Be sure to mention any related issues by number, so we can refer to past
+    discussion. GitHub will properly format a reference of the format `#100`.
   * If you are using a library (ev3dev-lang, python-ev3, ev3dev-c, etc.) please
     state which library. Most, if not all, of these have their own issues tracker.
     You may have better luck posting there instead.
@@ -69,7 +67,7 @@ In the description of your issue, be sure to also include:
     `systemctl status brickman.service -l`.
   * If a screenshot of the EV3 would be helpful, run `fbgrab <some-name>.png`
     on the EV3 and include the picture in your comments.
-<p />
+<br/>
 
 We also expect you to clean up after yourself. Please close the issue when
 you feel that it is resolved.
@@ -77,7 +75,7 @@ you feel that it is resolved.
 Some additional things to take into consideration:
 
 *   If you are posting logs that are more than 5-10 lines long, please use
-    <http://pastebin.com> or <https://gist.github.com> or something similar
+    <http://pastebin.com>, <https://gist.github.com> or something similar
     instead of posting long logs in comments.
 
 *   If you are copying and pasting information from a terminal, use "code fences"
@@ -96,7 +94,10 @@ Learn more about [writing on GitHub]{:target="_blank"}.
 Gitter
 ------
 
-[gitter.im] is an online chat service that works in conjunction with GitHub.
+[gitter.im] is an online chat service that works in conjunction with GitHub. We
+monitor our Gitter room and are happy to provide support in live chat.
+
+**This is the recommended means of live chat support for ev3dev.**
 
 If you have a GitHub or Twitter account, come say hello at <https://gitter.im/ev3dev/chat>.
 
@@ -124,8 +125,8 @@ browser. Just enter a nickname and click start below.
 <iframe src="https://kiwiirc.com/client/irc.freenode.net/?&theme=cli#ev3dev" class="button" style="width:100%; height:450px; border: none;" />
 
 [GitHub Issues]: https://help.github.com/articles/about-issues/
-[ev3dev-lang]: https://github.com/ev3dev/ev3dev-lang
-[ev3dev-lang-issues]: https://github.com/ev3dev/ev3dev-lang/issues
+[ev3dev-lang-python]: https://github.com/rhempel/ev3dev-lang-python
+[ev3dev-lang-python-issues]: https://github.com/rhempel/ev3dev-lang-python/issues
 [new issue]: https://github.com/ev3dev/ev3dev/issues/new
 [writing on GitHub]: https://help.github.com/categories/writing-on-github/
 [Internet Relay Chat]: https://en.wikipedia.org/wiki/Internet_Relay_Chat

--- a/support.md
+++ b/support.md
@@ -4,6 +4,9 @@ redirect_from: /issues/index.html
 excerpt: "Have a problem or question? We are here to help - but you have to help us help you. We keep track of problems, suggestions and questions about ev3dev using GitHub Issues. This lets us keep everything in one place."
 ---
 
+* Table of Contents 
+{:toc} 
+
 <center>
 <h3>Have a problem or question?
     <br/>


### PR DESCRIPTION
This is mainly targeting formatting of titles, however I threw in a bunch of other minor things from my run-through of almost all pages:
- Wrapped lines
- Updated "share" page now that mindsensors.com has removed their poll
  - Re-formatted that page and added a "star" button using an unofficial library which brings you to our repo (note that it doesn't actually star upon click)
- Switched text on "support" page to reference ev3dev-lang-python, as ev3dev-lang is now useless for users and Python is the most common library in use.
- Updated "support" instructions now that we have an issue template
  - _Side-note: I think it would me nice to figure out how to shrink the "IRC" section, as it makes the Gitter section hard to spot and is the less-optimal option._
- Updated breadcrumbs to make them more human-readable

Demo is live here: http://wasabifan.github.io/ev3dev.github.io/docs/drivers/dc-motor-class/
