### PR TITLE
mention ALT-F2 option for pi users with HDMI in Getting Started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -175,9 +175,6 @@ MINDSTORMS boot splash and the red LEDs will be on. This is immediately
 followed by the ev3dev boot splash and the LEDs changing to orange. The
 LEDs indicate disk (SD card) activity.
 
-**Note:** If you are using Raspberry Pi hardware without a screen, just wait for
-the Activity LED to stop flashing, then go to the next step.
-
 After about one minute, the screen will go blank. This happens on the first boot
 only. The first boot takes longer than subsequent boots because the EV3
 has to create a unique SSH host ids and take care of a few other housekeeping
@@ -191,6 +188,13 @@ calculate an accurate percent value of the remaining energy, so this value is
 chosen. If the voltage drops below 5V the brick will turn off. All unsaved
 data will be lost. Keep in mind, that it may take a much longer time from 8V to
 6.5V than from 6.5V down to 5V!
+
+**Note:** If you are using Raspberry Pi hardware without a screen, just wait for
+the Activity LED to stop flashing, then go to the next step. If you have connected 
+the pi to a screen monitor via HDMI press `ALT-F2` at the end of the boot sequence. 
+This should take you to a login prompt. Login as 'robot' with password 'maker'. 
+
+
 </div>
 
 <div class="col-md-4">

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -193,7 +193,7 @@ data will be lost. Keep in mind, that it may take a much longer time from 8V to
 **Note:** If you are using Raspberry Pi hardware without a screen, just wait for
 the Activity LED to stop flashing, then go to the next step. If alternatively 
 you have connected the pi to a screen monitor via HDMI 
-press <kbd>Alt</kbd>+<kbd>F2</kbd> at the end of the boot sequence. 
+press <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F6</kbd> at the end of the boot sequence. 
 This should take you to a login prompt. Login as 'robot' with password 'maker'. 
 
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -168,6 +168,7 @@ the cape your are using.
 
 <div class="row">
 <div class="col-md-8" markdown="1">
+
 ## Step 4: Boot ev3dev
 
 Put the SD Card in your EV3 and power it on. At first, you will see the
@@ -190,8 +191,9 @@ data will be lost. Keep in mind, that it may take a much longer time from 8V to
 6.5V than from 6.5V down to 5V!
 
 **Note:** If you are using Raspberry Pi hardware without a screen, just wait for
-the Activity LED to stop flashing, then go to the next step. If you have connected 
-the pi to a screen monitor via HDMI press `ALT-F2` at the end of the boot sequence. 
+the Activity LED to stop flashing, then go to the next step. If alternatively 
+you have connected the pi to a screen monitor via HDMI 
+press <kbd>Alt</kbd>+<kbd>F2</kbd> at the end of the boot sequence. 
 This should take you to a login prompt. Login as 'robot' with password 'maker'. 
 
 


### PR DESCRIPTION
I propose adding to the Note to pi users in 'Step 4: Boot ev3dev' of the Start up Guide.  It tells pi users that they can boot to a login prompt on a connected screen by pressing ALT-F2.  I also Moved the note to pi users to end of section to not distract from EV3 setup.