### PR TITLE
link to connmanctl wiki and ALT-F2 hint for pi users

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -15,7 +15,7 @@ session. An alternative method is to connect the pi to an HDMI screen monitor
 and USB keyboard and press <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F6</kbd> at the end of
 the boot sequence to reach a login prompt (id: robot, password: maker). Once 
 connected, you can then set up additional connections using 
-[`connmanctl`](http://www.ev3dev.org/docs/tutorials/setting-up-wifi-using-the-command-line/) commands.
+[`connmanctl`](/docs/tutorials/setting-up-wifi-using-the-command-line/) commands.
 {: class="alert alert-info"}
 
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -9,10 +9,13 @@ help you out.
 
 
 {% include /style/icon.html type="info" %}
-For Raspberry Pi platforms with no display, you must use the wired Ethernet port
-to connect for the first time through a remote SSH session. If you connected an HDMI 
-screen monitor press ALT-F2 to get to a login prompt. You can set up additional 
-connections using 
+For Raspberry Pi platforms with no display 
+([to be able to use Brickman](http://lechnology.com/2016/05/adding-a-display-to-brickpi/)), 
+you must use the wired Ethernet port to connect for the first time through a remote SSH 
+session. An alternative is to connect the pi to an HDMI screen monitor 
+and USB keyboard and press <kbd>Alt</kbd>+<kbd>F2</kbd> at the end of
+the boot sequence to reach a login prompt (id: robot, password: maker). Once 
+connected, you can then set up additional connections using 
 [`connmanctl`](https://wiki.archlinux.org/index.php/Connman#Usage) commands.
 {: class="alert alert-info"}
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -10,8 +10,10 @@ help you out.
 
 {% include /style/icon.html type="info" %}
 For Raspberry Pi platforms with no display, you must use the wired Ethernet port
-to connect for the first time. You can set up additional connections using the
-`connmanctl` command through a remote SSH session.
+to connect for the first time through a remote SSH session. If you connected an HDMI 
+screen monitor press ALT-F2 to get to a login prompt. You can set up additional 
+connections using 
+[`connmanctl`](https://wiki.archlinux.org/index.php/Connman#Usage) commands.
 {: class="alert alert-info"}
 
 # Connecting to the Internet
@@ -37,6 +39,8 @@ Once you have plugged in a dongle, you can use Brickman's
 "**_Wireless and Networks_ > _Wi-Fi_**" menu to connect to a network. Make sure
 you check the "**Powered**" box so that it starts searching for Wi-Fi networks,
 and then choose the one you want from the list that appears.
+
+**Note** 
 
 ### With USB through a PC
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -12,11 +12,12 @@ help you out.
 For Raspberry Pi platforms with no display, you must use the 
 wired Ethernet port to connect for the first time through a remote SSH 
 session. An alternative method is to connect the pi to an HDMI screen monitor 
-and USB keyboard and press <kbd>Alt</kbd>+<kbd>F2</kbd> at the end of
+and USB keyboard and press <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F6</kbd> at the end of
 the boot sequence to reach a login prompt (id: robot, password: maker). Once 
 connected, you can then set up additional connections using 
-[`connmanctl`](https://wiki.archlinux.org/index.php/Connman#Usage) commands.
+[`connmanctl`](http://www.ev3dev.org/docs/tutorials/setting-up-wifi-using-the-command-line/) commands.
 {: class="alert alert-info"}
+
 
 # Connecting to the Internet
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -43,7 +43,6 @@ Once you have plugged in a dongle, you can use Brickman's
 you check the "**Powered**" box so that it starts searching for Wi-Fi networks,
 and then choose the one you want from the list that appears.
 
-**Note** 
 
 ### With USB through a PC
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -9,10 +9,9 @@ help you out.
 
 
 {% include /style/icon.html type="info" %}
-For Raspberry Pi platforms with no display 
-([to be able to use Brickman](http://lechnology.com/2016/05/adding-a-display-to-brickpi/)), 
-you must use the wired Ethernet port to connect for the first time through a remote SSH 
-session. An alternative is to connect the pi to an HDMI screen monitor 
+For Raspberry Pi platforms with no display, you must use the 
+wired Ethernet port to connect for the first time through a remote SSH 
+session. An alternative method is to connect the pi to an HDMI screen monitor 
 and USB keyboard and press <kbd>Alt</kbd>+<kbd>F2</kbd> at the end of
 the boot sequence to reach a login prompt (id: robot, password: maker). Once 
 connected, you can then set up additional connections using 


### PR DESCRIPTION
Added hyperlink to Connman wiki that gives basic commands to establish wifi/bluetooth connections on the pi.  In same paragraph, for pi users booting with HDMI screen added note about ALT-F2 to get login prompt.