### PR TITLE
Enhance downloads page

### DIFF
--- a/_includes/page-core/title.html
+++ b/_includes/page-core/title.html
@@ -13,6 +13,8 @@
     {% assign edit_path = repo_url | append: '/edit/master/' | append: page.path %}
 {% elsif page.path contains 'news/' %}
     {% assign show_news_link = 1 %}
+{% elsif page.path == 'download.md' %}
+    {% assign show_downloads_refresh_link = 1 %}
 {% endif %}
 
 <div class="page-header">
@@ -20,6 +22,8 @@
         <a class="btn btn-primary pull-right" href="{{ edit_path }}"><span class="glyphicon glyphicon-pencil"></span> Edit on Github</a>
     {% elsif show_news_link %}
         <a class="btn btn-primary pull-right" href="/news/atom.xml">Subscribe via Atom</a>
+    {% elsif show_downloads_refresh_link %}
+        <a class="btn btn-primary pull-right release-refresh-button"><span class="glyphicon glyphicon-refresh"></span> Reload releases</a>
     {% endif %}
     <h1>
         {{ page.title | xml_escape }}

--- a/javascripts/api-cache.js
+++ b/javascripts/api-cache.js
@@ -8,18 +8,20 @@ function supportsHtml5Storage() {
     }
 }
 
-function getApiValue(endpointUrl, cacheTime, callback) {
-    try {
-        var cacheData = supportsHtml5Storage() ? JSON.parse(localStorage[cacheKey]) : null;
-        // This does an exact match for the URL given. Different spacing, duplicate slashes,
-        // alternate caps, etc. will result in the cache being bypassed.
-        if (cacheData && cacheData[endpointUrl] && Date.now() - cacheData[endpointUrl].dateRetrieved < cacheTime) {
-            callback(cacheData[endpointUrl].requestResult);
-            return;
+function getApiValue(endpointUrl, cacheTime, callback, clearCache) {
+    if(!clearCache) {
+        try {
+            var cacheData = supportsHtml5Storage() ? JSON.parse(localStorage[cacheKey]) : null;
+            // This does an exact match for the URL given. Different spacing, duplicate slashes,
+            // alternate caps, etc. will result in the cache being bypassed.
+            if (cacheData && cacheData[endpointUrl] && Date.now() - cacheData[endpointUrl].dateRetrieved < cacheTime) {
+                callback(cacheData[endpointUrl].requestResult);
+                return;
+            }
         }
-    }
-    catch (e) {
-        // Ignore the error; if the saved JSON is invalid, we'll just request it from the server.
+        catch (e) {
+            // Ignore the error; if the saved JSON is invalid, we'll just request it from the server.
+        }
     }
     
     console.log('No cached copy of API data for endpoint "' + endpointUrl  + '" found. Downloading from remote server.');

--- a/javascripts/releases.js
+++ b/javascripts/releases.js
@@ -62,10 +62,16 @@ function initDownloadLinks(clearCache) {
             }
 
             $linkElem.attr('href', targetRelease.downloadUrl);
-            $linkElem.children('small.download-size-label').remove();
 
+            $linkElem.data('toggle', 'tooltip');
+            $linkElem.data('placement', 'right');
+            $linkElem.attr('title', targetRelease.releaseName);
+
+            $linkElem.children('small.download-size-label').remove();
             var fileSize = targetRelease.size >> 20;
             $('<small/>').addClass('download-size-label').text(' (' + fileSize + ' MiB)').appendTo($linkElem);
+
+            $linkElem.tooltip();
         });
     },
     function (error) {


### PR DESCRIPTION
This does three things:
- Re-writes the release logic to be much less ugly
- Adds a "refresh" button which re-loads the download data, bypassing the 20-minute cache
- Adds a tooltip which shows the release name

I'd recommend viewing the two commits individually.

Here's a screenshot, because I can't publish at the moment:

![image](https://cloud.githubusercontent.com/assets/3310349/22850862/a31dffb4-efc6-11e6-8d64-68e2f5dd5b0c.png)

Fixes #338 

### This should be merged as a rebase; do not squash this PR.

