### PR TITLE
Add information for Debian and derivatives

### DIFF
--- a/docs/tutorials/connecting-to-the-internet-via-bluetooth.md
+++ b/docs/tutorials/connecting-to-the-internet-via-bluetooth.md
@@ -190,7 +190,8 @@ If you are using an older version, please upgrade.
     {: .alert .alert-info}
 
     1.  The default Bluetooth and network settings in Ubuntu do not have support for
-        this, so first you need to install `blueman` on your host computer.
+        this, so first you need to install `blueman` on your host computer. Make sure
+        you have the `bridge-utils` package too, it's required.
 
             sudo apt-get install blueman
 

--- a/docs/tutorials/connecting-to-the-internet-via-bluetooth.md
+++ b/docs/tutorials/connecting-to-the-internet-via-bluetooth.md
@@ -193,7 +193,7 @@ If you are using an older version, please upgrade.
         this, so first you need to install `blueman` on your host computer. Make sure
         you have the `bridge-utils` package too, it's required.
 
-            sudo apt-get install blueman
+            sudo apt-get install blueman bridge-utils
 
     2.  Run the Blueman *Bluetooth Manager*.
 


### PR DESCRIPTION
In Debian at least, the package brigde-utils needs to be installed manually. Without it, there is no pan1 network bridge and the bnep connection will fail, without indicating what the problem is.