### PR TITLE
Fix broken link so that Travis doesn't fail

### DIFF
--- a/news/_posts/2016-11-12-python-ev3dev-release-0-8-0.md
+++ b/news/_posts/2016-11-12-python-ev3dev-release-0-8-0.md
@@ -46,4 +46,4 @@ sudo apt-get update
 sudo apt-get install --only-upgrade python3-ev3dev
 {% endhighlight %}
 
-[fonts]: http://ev3dev-lang.readthedocs.io/projects/python-ev3dev/en/stable/other.html#bitmap-fonts
+[fonts]: http://ev3dev-lang-python.readthedocs.io/en/stable/other.html?highlight=bitmap%20fonts#bitmap-fonts


### PR DESCRIPTION
The information on bitmap fonts moved in the site. This is the updated link.