### PR TITLE
Replace defunct MinuteBot link

### DIFF
--- a/projects/_posts/2016-08-07-Mapping.md
+++ b/projects/_posts/2016-08-07-Mapping.md
@@ -282,4 +282,4 @@ If you have some question or problem open an issue in one of the [ev3dev-mapping
 [WebGL]: https://www.khronos.org/webgl/
 [W3C]: https://www.w3.org/
 
-[MinuteBot]: http://www.minutebot.com/minuteproducts/base/
+[MinuteBot]: http://web.archive.org/web/20160630211503/http://www.minutebot.com/minuteproducts/base


### PR DESCRIPTION
The minutebot domain appears to be down. This has been causing Travis CI to fail on every build, and GitHub to mark commits with "check failed." Replace the link with the most recent archive of that page.