### PR TITLE
Hide redirected pages from search and use firendly breadcrumbs

### DIFF
--- a/search-index.json
+++ b/search-index.json
@@ -19,23 +19,29 @@ layout:
         "href":"{{ page.url }}",
         "loopid":"page-{{ forloop.index }}",
         "category":"{{ page.categories }}",
-        {% capture _ %}
+        {% capture _ %} Capturing the generated content will prevent whitespace from being rendered
+
         {% assign parent_dirs=page.url | replace_first: '/', '' | split: '/' %}
         {% assign current_dir = site.data.breadcrumbs %}
         {% assign breadcrumbs = '' %}
+
         {% if parent_dirs.empty %}
+            Show just a slash to indicate the site root for empty breadcrumbs
             {% assign breadcrumbs = '/' %}
         {% else %}
             {% for dir in parent_dirs %}
+                Unless overridden, the "pretty" name will be the URL/directory name
                 {% assign pretty_name = dir %}
-                {% unless forloop.last %}
+                {% unless forloop.last %} The last iteration is the current page, which we don't want in breadcrumbs
+                    Traverse the tree of breadcrumb segment overrides
                     {% assign current_dir = current_dir[dir] %}
-                    {% if current_dir.name %}
-                    {% assign pretty_name = current_dir.name  %}
+                    {% if current_dir.name %} Override the pretty name if one is present in the data file
+                        {% assign pretty_name = current_dir.name  %}
                     {% endif %}
 
+                    Append the chosen name for this segment
                     {% assign breadcrumbs = breadcrumbs | append: pretty_name %}
-                    {% unless forloop.rindex0 <= 1 %}
+                    {% unless forloop.rindex0 <= 1 %} Append a separator if this isn't the last segment
                         {% assign breadcrumbs = breadcrumbs | append: " > " %}
                     {% endunless %}
                 {% endunless %}

--- a/search-index.json
+++ b/search-index.json
@@ -1,26 +1,50 @@
 ---
 layout:
 ---
+{% capture json %}
 [
     {% for post in site.posts %}
     {
-      "title"    : "{{ post.title }}",
-        "href": "{{ post.url }}",
-        "author":  "{{ post.author | join: ', ' }}",
-        "date": "{{ post.date | date_to_long_string }}",
-        "loopid" : "post-{{ forloop.index }}",
-        "category": "{{ post.categories }}"
-    },
-    {% endfor %}    
-    {% for page in site.pages %}
-    {
-      "title"    : "{{ page.title }}",
-      "href"     : "{{ page.url }}",
-      "loopid": "page-{{ forloop.index }}",
-      "category": "{{ page.categories }}",
-      {% assign parent_dirs=page.url | replace_first: '/', '' | split: '/' %}
-      "breadcrumbs": "{{ parent_dirs | join: ' > ' }}"
+        "title":"{{ post.title }}",
+        "href":"{{ post.url }}",
+        "author":"{{ post.author | join: ', ' }}",
+        "date":"{{ post.date | date_to_long_string }}",
+        "loopid":"post-{{ forloop.index }}",
+        "category":"{{ post.categories }}"
     },
     {% endfor %}
-    false    
+    {% for page in site.pages %}{% unless page.redirect_to %}
+    {
+        "title":"{{ page.title }}",
+        "href":"{{ page.url }}",
+        "loopid":"page-{{ forloop.index }}",
+        "category":"{{ page.categories }}",
+        {% capture _ %}
+        {% assign parent_dirs=page.url | replace_first: '/', '' | split: '/' %}
+        {% assign current_dir = site.data.breadcrumbs %}
+        {% assign breadcrumbs = '' %}
+        {% if parent_dirs.empty %}
+            {% assign breadcrumbs = '/' %}
+        {% else %}
+            {% for dir in parent_dirs %}
+                {% assign pretty_name = dir %}
+                {% unless forloop.last %}
+                    {% assign current_dir = current_dir[dir] %}
+                    {% if current_dir.name %}
+                    {% assign pretty_name = current_dir.name  %}
+                    {% endif %}
+
+                    {% assign breadcrumbs = breadcrumbs | append: pretty_name %}
+                    {% unless forloop.rindex0 <= 1 %}
+                        {% assign breadcrumbs = breadcrumbs | append: " > " %}
+                    {% endunless %}
+                {% endunless %}
+            {% endfor %}
+        {% endif %}
+        {% endcapture %}
+        "breadcrumbs":"{{ breadcrumbs }}"
+    },
+    {% endunless %}{% endfor %}
+    false
 ]
+{% endcapture %}{{ json | replace:"  "," "  | replace:"  "," "  | replace:"  "," "  | replace:"  "," " }}


### PR DESCRIPTION
GitHub's super unhappy with this diff 😀 

I took advantage of time with this file to also do some slight minification; there's significantly less whitespace in there now. I'd guess it is 30% smaller just from whitespace, and the removed docs pages bring that to something more like a 80% reduction.

Fixes #323 
