### PR TITLE
Fix driver repo links

### DIFF
--- a/docs/kernel-hackers-notebook/ev3-i2c.md
+++ b/docs/kernel-hackers-notebook/ev3-i2c.md
@@ -40,4 +40,4 @@ See [I2C Sensor Addressing](http://docs.ev3dev.org/projects/lego-linux-drivers/e
 [framework for I2C drivers]: https://www.kernel.org/doc/Documentation/i2c/
 [drivers/i2c/busses/i2c-davinci.c]: https://github.com/ev3dev/ev3-kernel/blob/ev3dev-jessie/drivers/i2c/busses/i2c-davinci.c
 [arch/arm/mach-davinci/legoev3-fiq.c]: https://github.com/ev3dev/ev3-kernel/blob/ev3dev-jessie/arch/arm/mach-davinci/legoev3-fiq.c
-[drivers/i2c/busses/i2c-legoev3.c]: https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_i2c.c
+[drivers/i2c/busses/i2c-legoev3.c]: https://github.com/ev3dev/lego-linux-drivers/blob/ev3dev-jessie/ev3/legoev3_i2c.c

--- a/docs/kernel-hackers-notebook/ev3-uart.md
+++ b/docs/kernel-hackers-notebook/ev3-uart.md
@@ -28,7 +28,7 @@ device class. The interesting part is the LEGOEV3 [line discipline] that runs
 on top of the tty driver.
 
 ### LEGOEV3 Line Discipline
-Source: [ev3_uart_sensor_ld.c](https://github.com/ev3dev/lego-linux-drivers/blob/master/sensors/ev3_uart_sensor_ld.c)
+Source: [ev3_uart_sensor_ld.c](https://github.com/ev3dev/lego-linux-drivers/blob/ev3dev-jessie/sensors/ev3_uart_sensor_ld.c)
 
 There are udev rules in place ([ev3.rules] in conjunction with [ev3-uart@.service])
 that attach the line discipline to a tty (serial port) when a UART sensor is

--- a/docs/kernel-hackers-notebook/ev3dev-linux-kernel.md
+++ b/docs/kernel-hackers-notebook/ev3dev-linux-kernel.md
@@ -121,15 +121,15 @@ drivers to LMS2012 drivers.
 
 Most everything is in the [lego-linux-drivers] repository nowadays.
 
-[legoev3_analog.c]: https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_analog.c
-[legoev3_ports_in.c]: https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_ports_in.c
-[legoev3_ports_out.c]: https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_ports_out.c
-[legoev3_bluetooth.c]: https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_bluetooth.c
-[legoev3_i2c.c]: https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_i2c.c
-[legoev3_battery.c]: https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_battery.c
-[legoev3_motor.c]: https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_motor.c
-[tacho_motor_class.c]: https://github.com/ev3dev/lego-linux-drivers/blob/master/motors/tacho_motor_class.c
-[legoev3_sound.c]: https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_sound.c
+[legoev3_analog.c]: https://github.com/ev3dev/lego-linux-drivers/blob/ev3dev-jessie/ev3/legoev3_analog.c
+[legoev3_ports_in.c]: https://github.com/ev3dev/lego-linux-drivers/blob/ev3dev-jessie/ev3/legoev3_ports_in.c
+[legoev3_ports_out.c]: https://github.com/ev3dev/lego-linux-drivers/blob/ev3dev-jessie/ev3/legoev3_ports_out.c
+[legoev3_bluetooth.c]: https://github.com/ev3dev/lego-linux-drivers/blob/ev3dev-jessie/ev3/legoev3_bluetooth.c
+[legoev3_i2c.c]: https://github.com/ev3dev/lego-linux-drivers/blob/ev3dev-jessie/ev3/legoev3_i2c.c
+[legoev3_battery.c]: https://github.com/ev3dev/lego-linux-drivers/blob/ev3dev-jessie/ev3/legoev3_battery.c
+[legoev3_motor.c]: https://github.com/ev3dev/lego-linux-drivers/blob/ev3dev-jessie/ev3/legoev3_motor.c
+[tacho_motor_class.c]: https://github.com/ev3dev/lego-linux-drivers/blob/ev3dev-jessie/motors/tacho_motor_class.c
+[legoev3_sound.c]: https://github.com/ev3dev/lego-linux-drivers/blob/ev3dev-jessie/ev3/legoev3_sound.c
 [board-legoev3.c]: https://github.com/ev3dev/ev3-kernel/blob/ev3dev-jessie/arch/arm/mach-davinci/board-legoev3.c
 [legoev3-fiq.c]: https://github.com/ev3dev/ev3-kernel/blob/ev3dev-jessie/arch/arm/mach-davinci/legoev3-fiq.c
 [st7586fb.c]: https://github.com/ev3dev/ev3-kernel/blob/ev3dev-jessie/drivers/video/st7586fb.c


### PR DESCRIPTION
```
- ./docs/kernel-hackers-notebook/ev3-uart/index.html
  *  External link https://github.com/ev3dev/lego-linux-drivers/blob/master/sensors/ev3_uart_sensor_ld.c failed: 404 No error
- ./docs/kernel-hackers-notebook/ev3dev-linux-kernel/index.html
  *  External link https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_analog.c failed: 404 No error
  *  External link https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_battery.c failed: 404 No error
  *  External link https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_bluetooth.c failed: 404 No error
  *  External link https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_i2c.c failed: 404 No error
  *  External link https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_motor.c failed: 404 No error
  *  External link https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_ports_in.c failed: 404 No error
  *  External link https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_ports_out.c failed: 404 No error
  *  External link https://github.com/ev3dev/lego-linux-drivers/blob/master/ev3/legoev3_sound.c failed: 404 No error
  *  External link https://github.com/ev3dev/lego-linux-drivers/blob/master/motors/tacho_motor_class.c failed: 404 No error
```