### PR TITLE
[WIP] Add docs on mounting NFS share via systemd

### DIFF
--- a/docs/tutorials/setting-up-an-nfs-file-share.md
+++ b/docs/tutorials/setting-up-an-nfs-file-share.md
@@ -99,17 +99,11 @@ If you make changes to `/etc/exports`, activate them with `nfsd update`.
 
 ## How To Do It - EV3
 
-On the client - ev3dev - side, we need to create a system mount unit in order to mount our newly created NFS share. **Note**: The classic way of mounting the NFS share via an entry in /etc/fstab does not work!
+On the client - ev3dev - side, we need to create, test and enable a systemd `mount.unit` file in order to mount our newly created NFS share. {% include /style/icon.html type="warning" %}
+The classic way of mounting the NFS share via an entry in /etc/fstab does not work!
+{: .alert .alert-warning}
 
-First off, we need the NFS kernel module. Open an SSH connection to ev3dev and type the following:
-
-    modprobe nfs
-    
-To make this persistent across reboots, we need to add NFS to the module file:
-
-    echo NFS >> /etc/modules
-    
-Next, we need to create a system mount unit file. This file needs to be named after the directory where we want to mount our NSF share, with the slashes replaced by hyphens. For this tutorial, we will mount the NFS share at `/home/robot/nfsshare/` - feel free to change this to suit your needs. 
+First off, we need to create our `mount.unit` file. This file needs to be named after the directory where we want to mount our NSF share, with the slashes replaced by hyphens. For this tutorial, we will mount the NFS share at `/home/robot/nfsshare/` - feel free to change this to suit your needs. 
 
 Create and open the file `/etc/systemd/system/home-robot-nfsshare.mount`. Add the following sections:
 
@@ -133,17 +127,17 @@ The `[Install]` section describes, when to start this unit after it has been ena
 
 In order to mount the NFS share, you first need to reload the systemd daemon:
 
-    systemctl daemon-reload
+    sudo systemctl daemon-reload
     
 Then, we need to start the mount unit we have just created:
 
-    systemctl start home-robot-nfsshare.mount
+    sudo systemctl start home-robot-nfsshare.mount
     
 To verify that everything worked, look into the `/home/robot/nfsshare` directory and check that the files from your NFS share are there. **Note**: The directory `/home/robot/nfsshare` should have been created automatically.
 
 If you want your NFS share to be mounted at boot, you need to enable the mount unit by typing:
 
-    systemctl enable home-robot-nfsshare.mount
+    sudo systemctl enable home-robot-nfsshare.mount
 
 
 ## References

--- a/docs/tutorials/setting-up-an-nfs-file-share.md
+++ b/docs/tutorials/setting-up-an-nfs-file-share.md
@@ -1,7 +1,7 @@
 ---
 title: Setting Up an NFS File Share
 group: advanced-networking
-author: [ "@antonvh","@rhempel","JNFitzgerald" ]
+author: [ "@antonvh","@rhempel","JNFitzgerald", "Jesko Appelfeller" ]
 ---
 
 * Table of Contents
@@ -101,52 +101,6 @@ Now update the fstab on the EV3.
 
 ## How To Do It - EV3
 
-On the EV3 we first need to enable and start NFS modules. Type these commands on the command line:
-
-    sudo systemctl enable nfs-common.service
-    sudo systemctl start nfs-common.service
-    sudo systemctl enable rpcbind.service
-    sudo systemctl start rpcbind.service
-
-Next you'll need to update a file (as root) called `/etc/fstab`. You should have already set up USB Networking, so `ssh` to the EV3 and run an editor like `vi` or `nano` to edit the file. Here's the line you want to add to `/etc/fstab` - DO NOT TOUCH ANYTHING ELSE IN THERE!
-
-
-    # NOTE - the following examples all use the same IP address for the host, in practice, there would
-    #        be separate addresses for each host!
-
-    # For the Linux example, it would look like:
-    192.168.2.1:/home/hostuserid/nfs/ev3dev /home/robot/nfs/linux   nfs users,noauto,rw,vers=3  0 0
-
-    # For the Windows Hanewin example, it would look like:
-    192.168.0.199:\E\Users\James\Dropbox\ev3dev                       /home/robot/nfs/windows nfs users,noauto,rw,vers=3  0 0
-
-    # For the OSX example, it would look like:
-    192.168.2.1:/Users/youruserid/Public    /home/robot/nfs/osx     nfs users,noauto,rw,vers=3  0 0
-
-
-It's not too hard to figure out what's going on here. The host machine with the nfs mount is at `192.168.2.1` and we added `/home/hostuserid/nfs/ev3dev` (or whatever the host is exporting the directory as) to the `/etc/exports` file on that machine. The next section of the line says we want to mount it locally at `/home/ev3userid/nfs/linux`, or whatever directory you choose.
-
-The options tell `mount` that:
-
-- this is an nfs share
-- we do not want to automatically mount it at boot time (in case the host is not connected)
-- general users are allowed to mount the share
-- we want read/write access
-- we are using nfs V3 on the host
-
-Once you've updated the `/etc/fstab` file, you will need to create the mount points. Since I test `ev3dev` o n all three major platforms, I have separate directories for each nfs host. You probably only need to create one of these, but this script creates all three for me:
-
-    mkdir -p ~/nfs/linux
-    mkdir -p ~/nfs/windows
-    mkdir -p ~/nfs/osx
-
-Then all you need to do is mount the share, like this: 
-
-    mount ~/nfs/linux
-    
-...or whichever of the above three directories you want to mount.
-
-And then you should be able to see the files on your host computer when you do `ls /home/ev3userid/nfs/ev3dev`!
 
 ## References
 

--- a/docs/tutorials/setting-up-an-nfs-file-share.md
+++ b/docs/tutorials/setting-up-an-nfs-file-share.md
@@ -99,8 +99,10 @@ If you make changes to `/etc/exports`, activate them with `nfsd update`.
 
 ## How To Do It - EV3
 
-On the client - ev3dev - side, we need to create, test and enable a systemd `mount.unit` file in order to mount our newly created NFS share. {% include /style/icon.html type="warning" %}
-The classic way of mounting the NFS share via an entry in /etc/fstab does not work!
+On the client - ev3dev - side, we need to create, test and enable a systemd `mount.unit` file in order to mount our newly created NFS share.
+
+{% include /style/icon.html type="warning" %}
+The classic way of mounting the NFS share via an entry in `/etc/fstab` does not work! It can cause ev3dev to hang during boot up.
 {: .alert .alert-warning}
 
 First off, we need to create our `mount.unit` file. This file needs to be named after the directory where we want to mount our NSF share, with the slashes replaced by hyphens. For this tutorial, we will mount the NFS share at `/home/robot/nfsshare/` - feel free to change this to suit your needs. 


### PR DESCRIPTION
Hey, two quick questions:

1. Should I leave in the old section on mounting an NFS share via fstab, or should I remove it?
1. The [original tutorial](https://cloudnull.io/2017/05/nfs-mount-via-systemd/) used the `machines.target` target for the mount unit file. I don't think that makes much sense for ev3dev. In my setup, I simply user `multi-user.target`. I'm not familiar with the ev3dev boot process though. Any other target you would prefer?