### PR TITLE
Mapping - honorably mention code reused in NASA Astrobee ISAAC flight software

### DIFF
--- a/projects/_posts/2016-08-07-Mapping.md
+++ b/projects/_posts/2016-08-07-Mapping.md
@@ -38,6 +38,10 @@ The meta-repository of the project is [ev3dev-mapping].
 This is my personal project. While I am quite happy to share the results, please keep in mind that I am pursuing my own goals here.
 </div>
 
+<div class="alert alert-info" markdown="1">
+{% include /style/icon.html type="info" %}
+Some of the generic [libraries](https://github.com/bmegli/wifi-scan) written for this project [ended up](https://github.com/nasa/isaac/blob/3a7bdcae46e255cb9060a80f1a6e70af187f631c/astrobee/hardware/wifi/include/wifi/wifi.h#L2) in NASA ISAAC flight [software](https://nasa.github.io/isaac/html/wifi_driver.html) for Astrobee robot operating inside the International Space Station. That's some open source in the wild!
+</div>
 
 ## Examples
 
@@ -157,7 +161,9 @@ The position and heading data is interpolated individually for each laser readin
 The `drive component` translates input from the user (keyboard, pad, numerical, ...) using the motion model and sends it to the `drive module`.
 The `drive module` controls the motors.
 
-The `control component` and the `control module` are not in the scheme for clarity. The `control component` sends to `control module` requests to enable/disable modules.
+The `wifi component` and the `wifi module` are not in the scheme for clarity. The `wifi module` sends wireless signal strength information to the `wifi component`. The data is reflected in the UI.
+
+The `control component` and the `control module` are not in the scheme for clarity. The `control component` sends to the `control module` requests to enable/disable modules.
 The `control module` replies with module states. 
  
 ## Building Instructions
@@ -212,6 +218,8 @@ If you have some question or problem open an issue in one of the [ev3dev-mapping
 
 [mi-xg1300l] - CruizCore XG1300L driver documentation
 
+[wifi-scan] - C/C++ library for monitoring signal strength of WiFi networks 
+
 [X3DOM] - open-source framework for declarative 3D graphics on the Web
 
 ### tutorials and learning
@@ -265,6 +273,7 @@ If you have some question or problem open an issue in one of the [ev3dev-mapping
 
 [xv11lidar]: https://github.com/bmegli/xv11lidar
 [mi-xg1300l]: https://docs.ev3dev.org/projects/lego-linux-drivers/en/ev3dev-jessie/sensor_data.html#mi-xg1300l
+[wifi-scan]: https://github.com/bmegli/wifi-scan
 
 [How to interface XV11 LIDAR to EV3 using ev3dev]: https://www.youtube.com/watch?v=G6uVg34VzHw
 [EV3 Gyro vs CruizCore XG1300L vs Odometry - Position Estimation]: https://www.youtube.com/watch?v=vzND_ISdhEs


### PR DESCRIPTION
[`wifi-module`](https://github.com/bmegli/ev3dev-mapping-modules/tree/master/ev3wifi)
- the `wifi module` was originally omitted in description for clarity
  - as not ev3dev specific enough
- to implement module a separate library `wifi-scan` was written

[`wifi-scan`](https://github.com/bmegli/wifi-scan) library
- code was [reused](https://github.com/nasa/isaac/blob/3a7bdcae46e255cb9060a80f1a6e70af187f631c/astrobee/hardware/wifi/include/wifi/wifi.h#L2) in NASA Astrobee ISAAC flight [software](https://nasa.github.io/isaac/html/wifi_driver.html) 
- and deserves at least a honorable mention and link
- as ev3dev project spin-off that [launched](https://www.nasa.gov/image-feature/ames/astrobee-space-bots-mark-a-new-milestone-in-human-robot-teamwork) into space...