### PR TITLE
Update connecting-to-ev3dev-with-ssh.md

### DIFF
--- a/docs/tutorials/connecting-to-ev3dev-with-ssh.md
+++ b/docs/tutorials/connecting-to-ev3dev-with-ssh.md
@@ -51,7 +51,7 @@ you have configured a network connection before continuing.
 *   {: tab="Ubuntu"}
     Type the following command in a terminal window.
 
-        ssh robot@ev3dev.local
+        ssh -o PreferredAuthentications=password robot@ev3dev.local
 
     <div class="panel panel-info">
     <div class="panel-heading">


### PR DESCRIPTION
-o PreferredAuthentications=password is necessary if your ssh client is set to try other methods first. We could instead offer this as a response to the error message "Received disconnect from 192.168.0.1 port 22:2: Too many authentication failures"