### PR TITLE
Add EV3Aero project to projects list

### DIFF
--- a/projects/_posts/2025-05-26-EV3Aero.md
+++ b/projects/_posts/2025-05-26-EV3Aero.md
@@ -1,0 +1,26 @@
+---
+title: EV3Aero
+author: ["@Slashingbee"]
+programming_language: Python
+project_homepage_url: https://github.com/Slashingbee/EV3Aero
+source_code_url: https://github.com/Slashingbee/EV3Aero
+building_instructions_url: https://github.com/Slashingbee/EV3Aero#installation
+excerpt: Modular flight controller for LEGO Mindstorms EV3 running ev3dev. Build custom flight simulator controllers using LEGO motors and sensors.
+---
+
+EV3Aero is an open-source project that allows you to build a modular flight controller using LEGO Mindstorms EV3 running ev3dev. The system enables creating joysticks, throttles, and other flight controls compatible with flight simulators.
+
+## Features
+
+- Modular design allowing flexible hardware customization.
+- Uses LEGO motors and sensors for unique, customizable controllers.
+- Compatible with various flight simulators.
+- Open source under the Apache-2.0 license.
+
+## Installation and Usage
+
+Detailed installation and setup instructions are available in the [README](https://github.com/Slashingbee/EV3Aero#installation).
+
+---
+
+Feel free to contribute, test, and develop new features for the project!


### PR DESCRIPTION
This pull request adds a new project, EV3Aero, to the official ev3dev projects page. EV3Aero is a modular flight controller built with LEGO Mindstorms EV3 running ev3dev, enabling users to create custom flight simulator controllers using LEGO motors and sensors.

Includes project metadata and description in markdown format

Links to the GitHub repository and installation instructions

Categorized under “projects” for automatic listing on the projects page

Looking forward to feedback and contributions from the community!