### PR TITLE
Correct the bootloader magic address

### DIFF
--- a/docs/kernel-hackers-notebook/ev3-eeprom.md
+++ b/docs/kernel-hackers-notebook/ev3-eeprom.md
@@ -48,7 +48,7 @@ If you have a serial terminal connected to Input Port 1, you will see the follow
 
     Jumping to entry point at: 0xC1080000
 
-NOTE: You can enter firmware update mode by writing 0x5555AAAA to memory address 0xFFFF1FFA (part of the 128K on-chip ram of the AM1808 processor) and then rebooting with `reboot -d -f -i`. This reboots without properly shutting down (see `reboot --help`), so we don't want to do this in ev3dev. On the official LEGO firmware, the firmware update writes over everything so it doesn't matter if it does not shut down properly. 
+NOTE: You can enter firmware update mode by writing 0x5555AAAA to memory address 0xFFFF1FFC (part of the 128K on-chip ram of the AM1808 processor) and then rebooting with `reboot -d -f -i`. This reboots without properly shutting down (see `reboot --help`), so we don't want to do this in ev3dev. On the official LEGO firmware, the firmware update writes over everything so it doesn't matter if it does not shut down properly. 
 
 ## Hardware Version
 


### PR DESCRIPTION
The bootloader contains

```
80004080  c4cf9fe5   ldr     r12, data_8000504c  {0xffff1ffc}
80004084  00c09ce5   ldr     r12, [r12]  {0xffff1ffc}
80004088  08c08de5   str     r12, [sp,  #0x8] {var_28}
```

and later

```
800044a4  d00b9fe5   ldr     r0, data_8000507c  {0x5555aaaa}
800044a8  08c09de5   ldr     r12, [sp,  #0x8] {var_28}
800044ac  0c0050e1   cmp     r0, r12
800044b0  0100000a   beq     0x800044bc
```

The listed address is also not 4-byte aligned.